### PR TITLE
feat: free-text Discogs search via q param

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,3 +63,7 @@ jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
 ### Styling
 
 TailwindCSS with DaisyUI component classes. Theme is set via `data-theme` on `<html>` — driven by `config.colors.theme` from `config.ts`. Global styles are in `app/globals.css`.
+
+## Vision
+
+The long-term goal is frictionless vinyl pricing: point a camera at an album cover and get an estimated price. The intended approach is to send a captured frame to a vision LLM (e.g. Claude Haiku) server-side, extract artist and title, then pass that as a free-text query to the existing Discogs pipeline. Text search is an interim input method on the way to that goal.

--- a/app/search/components/RecordSearchForm.tsx
+++ b/app/search/components/RecordSearchForm.tsx
@@ -18,34 +18,15 @@ interface LookUpFormProps {
     const { register, handleSubmit, reset, formState: { errors }, setError } = useForm<FormData>({reValidateMode: 'onSubmit'});
   
     const onSubmit: SubmitHandler<FormData> = async (data) =>{
-  
-        let title: string;
-        let artist: string;
-        
+
         if (!data.term.trim()) {
             setError("term", { type: "manual", message: "Search term is empty" });
             return;
         }
 
-        const terms = data.term.split(",");
-
-        if (terms.length < 1 || terms.length > 2) {
-            setError("term", { type: "manual", message: "Invalid number of terms" });
-            return;
-        }
-
-        if (terms.length >= 1) {
-            title = terms[0].trim();
-        }
-
-        if (terms.length >= 2) {
-            artist = terms[1].trim();
-        }
-  
         setLoading(true);
         try {
-            console.log(`Finding release with query - title: ${title}, artist: ${artist}`);
-            const response = await findRelease(title, artist);
+            const response = await findRelease(data.term.trim());
             onRecordSearch(response);
         } catch (error) {
             setError("term", { type: "manual", message: "Couldn't find release" });
@@ -63,7 +44,7 @@ interface LookUpFormProps {
                 <span 
                     data-tooltip-id="tooltip" 
                     className="label-text-alt tooltip badge badge-secondary badge-outline" 
-                    data-tooltip-content="Search by the album title, the artist name is optional and should be separated by a comma (eg. Abbey Road, The Beatles)">
+                    data-tooltip-content="Search by album title, artist, or both (eg. Abbey Road, or Abbey Road The Beatles)">
                         Help</span>
             </label>
             <div className="flex w-full space-x-2">

--- a/app/search/search-service.test.ts
+++ b/app/search/search-service.test.ts
@@ -87,7 +87,7 @@ beforeEach(() => {
 
 describe('findRelease', () => {
   it('returns fully populated ReleaseData on happy path', async () => {
-    const result = await findRelease('Test Album', 'Artist A');
+    const result = await findRelease('Test Album Artist A');
 
     expect(result.title).toBe('Test Album');
     expect(result.year).toBe(1991);
@@ -98,20 +98,26 @@ describe('findRelease', () => {
     expect(result.noForSale).toBe(42);
   });
 
+  it('passes the raw query string to searchDiscogs', async () => {
+    await findRelease('Test Album Artist A');
+
+    expect(mockSearchDiscogs).toHaveBeenCalledWith('Test Album Artist A', expect.any(String), expect.any(String));
+  });
+
   it('concatenates discogs genres and styles into genres', async () => {
-    const result = await findRelease('Test Album', 'Artist A');
+    const result = await findRelease('Test Album Artist A');
 
     expect(result.genres).toEqual(['Rock', 'Pop', 'Indie Rock', 'Alternative']);
   });
 
   it('maps artist objects to an array of name strings', async () => {
-    const result = await findRelease('Test Album', 'Artist A');
+    const result = await findRelease('Test Album Artist A');
 
     expect(result.artists).toEqual(['Artist A', 'Artist B']);
   });
 
   it('derives track count from the tracklist length', async () => {
-    const result = await findRelease('Test Album', 'Artist A');
+    const result = await findRelease('Test Album Artist A');
 
     expect(result.noOfTracks).toBe(3);
   });
@@ -119,20 +125,20 @@ describe('findRelease', () => {
   it('throws when Discogs search returns no results', async () => {
     mockSearchDiscogs.mockResolvedValueOnce({ ...mockSearchResult, results: [] });
 
-    await expect(findRelease('Unknown', 'Nobody')).rejects.toThrow('No releases found');
+    await expect(findRelease('Unknown Nobody')).rejects.toThrow('No releases found');
   });
 
   it('throws when no search result has a master_id', async () => {
     const noMasterResult = { ...mockSearchResult, results: [{ ...mockSearchResult.results[0], master_id: 0 }] };
     mockSearchDiscogs.mockResolvedValueOnce(noMasterResult);
 
-    await expect(findRelease('Test Album', 'Artist A')).rejects.toThrow('No valid master ID found in search results');
+    await expect(findRelease('Test Album Artist A')).rejects.toThrow('No valid master ID found in search results');
   });
 
   it('sets originalPriceSuggestion to null and skips getPriceSuggestion when main_release is falsy', async () => {
     mockGetDiscogsMasterRelease.mockResolvedValueOnce({ ...mockMaster, main_release: 0 });
 
-    const result = await findRelease('Test Album', 'Artist A');
+    const result = await findRelease('Test Album Artist A');
 
     expect(mockGetPriceSuggestion).not.toHaveBeenCalled();
     expect(result.originalPriceSuggestion).toBeNull();
@@ -141,7 +147,7 @@ describe('findRelease', () => {
   it('sets rating count and average to null when rating is missing from response', async () => {
     mockGetRating.mockResolvedValueOnce({} as DiscogsRatingResponse);
 
-    const result = await findRelease('Test Album', 'Artist A');
+    const result = await findRelease('Test Album Artist A');
 
     expect(result.rating).toEqual({ count: null, average: null });
   });
@@ -149,7 +155,7 @@ describe('findRelease', () => {
   it('sets image to null when the master release has no images', async () => {
     mockGetDiscogsMasterRelease.mockResolvedValueOnce({ ...mockMaster, images: [] });
 
-    const result = await findRelease('Test Album', 'Artist A');
+    const result = await findRelease('Test Album Artist A');
 
     expect(result.image).toBeNull();
   });
@@ -157,14 +163,14 @@ describe('findRelease', () => {
   it('sets summary to null when Wikipedia returns no results', async () => {
     mockSearchWiki.mockResolvedValueOnce({ results: [] } as any);
 
-    const result = await findRelease('Test Album', 'Artist A');
+    const result = await findRelease('Test Album Artist A');
 
     expect(result.summary).toBeNull();
     expect(mockGetWikiSummary).not.toHaveBeenCalled();
   });
 
   it('calls revalidatePath("/") on success', async () => {
-    await findRelease('Test Album', 'Artist A');
+    await findRelease('Test Album Artist A');
 
     expect(mockRevalidatePath).toHaveBeenCalledTimes(1);
     expect(mockRevalidatePath).toHaveBeenCalledWith('/');

--- a/app/search/search-service.ts
+++ b/app/search/search-service.ts
@@ -22,10 +22,10 @@ export interface ReleaseData {
     } ;
 }
 
-export async function findRelease(title: string, artist: string): Promise<ReleaseData> {
+export async function findRelease(query: string): Promise<ReleaseData> {
 
-    console.log(`Finding release with query - title: ${title}, artist: ${artist}`);
-    
+    console.log(`Finding release with query: ${query}`);
+
     const type = "release";
     const format = "vinyl,album";
     let originalPriceSuggestion: ConditionValues| null = null;
@@ -35,7 +35,7 @@ export async function findRelease(title: string, artist: string): Promise<Releas
     let ratingCount: number | null = null;
     let wikiSource: string | null = null;
 
-    const searchResponse = await searchDiscogs(artist, title, type, format);
+    const searchResponse = await searchDiscogs(query, type, format);
     if (searchResponse.results.length === 0) throw new Error("No releases found");
     
     for (const result of searchResponse.results) {

--- a/libs/discogs.test.ts
+++ b/libs/discogs.test.ts
@@ -39,26 +39,27 @@ describe('searchDiscogs', () => {
       json: jest.fn().mockResolvedValueOnce(mockResults),
     });
 
-    const result = await searchDiscogs('Beatles', 'Abbey Road', 'release', 'vinyl');
+    const result = await searchDiscogs('Abbey Road Beatles', 'release', 'vinyl');
 
     expect(result).toEqual(mockResults);
   });
 
-  it('encodes title and artist as query parameters in the request URL', async () => {
+  it('encodes the query as the q parameter in the request URL', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({ json: jest.fn().mockResolvedValueOnce({}) });
 
-    await searchDiscogs('Beatles', 'Abbey Road', 'release', 'vinyl');
+    await searchDiscogs('Abbey Road Beatles', 'release', 'vinyl');
 
     const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
     const params = new URL(calledUrl).searchParams;
-    expect(params.get('artist')).toBe('Beatles');
-    expect(params.get('title')).toBe('Abbey Road');
+    expect(params.get('q')).toBe('Abbey Road Beatles');
+    expect(params.has('artist')).toBe(false);
+    expect(params.has('title')).toBe(false);
   });
 
   it('rethrows as "Error searching Discogs" when fetch throws', async () => {
     (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network error'));
 
-    await expect(searchDiscogs('Artist', 'Title', 'release', 'vinyl')).rejects.toThrow('Error searching Discogs');
+    await expect(searchDiscogs('Title Artist', 'release', 'vinyl')).rejects.toThrow('Error searching Discogs');
   });
 });
 

--- a/libs/discogs.ts
+++ b/libs/discogs.ts
@@ -19,8 +19,7 @@ export async function getDiscogsMasterRelease(masterId: number): Promise<Discogs
 
 /**
  * Performs a search on the Discogs database for records matching the specified criteria.
- * @param artist The name of the artist to search for.
- * @param title The title of the record to search for.
+ * @param query Free-text search query (e.g. "Rumours Fleetwood Mac").
  * @param type The type of release to search for (e.g., "release").
  * @param format The format of the release to search for (e.g., "vinyl,album").
  * @returns A promise that resolves with a DiscogsPaginatedSearchResult containing the search results.

--- a/libs/discogs.ts
+++ b/libs/discogs.ts
@@ -25,13 +25,12 @@ export async function getDiscogsMasterRelease(masterId: number): Promise<Discogs
  * @param format The format of the release to search for (e.g., "vinyl,album").
  * @returns A promise that resolves with a DiscogsPaginatedSearchResult containing the search results.
  */
-export async function searchDiscogs(artist: String, title: String, type: String, format: String): Promise<DiscogsPaginatedSearchResult> {
+export async function searchDiscogs(query: string, type: string, format: string): Promise<DiscogsPaginatedSearchResult> {
     try{
         const queryParams = {
             type: "release",
             format: "vinyl",
-            title: title,
-            artist: artist,
+            q: query,
         }
 
         const queryString = buildQuery(queryParams);


### PR DESCRIPTION
## What and why

Replaces the comma-separated `title, artist` input with a single free-text search box. The Discogs API's `q` parameter handles natural language queries directly, so no client-side parsing is needed.

This also sets up the right abstraction for the planned camera feature: a vision LLM will identify the album from a photo and produce a query string, which will flow into the same `searchDiscogs` call unchanged.

## Changes

- `libs/discogs.ts` — `searchDiscogs` drops `artist`/`title` params, adds `q`
- `app/search/search-service.ts` — `findRelease` accepts a single `query` string
- `app/search/components/RecordSearchForm.tsx` — removes comma-split logic; passes raw input to `findRelease`
- Tests updated to match new signatures; added assertion that the query string is passed through to `searchDiscogs` unchanged

## Test plan

- [ ] All 31 Jest tests pass (`npm test`)
- [ ] CI green on this PR
- [ ] Manual: search "Rumours Fleetwood Mac" on the deployment — returns correct album with pricing
- [ ] Manual: search "Kind of Blue" (title only) — returns correct album
- [ ] Manual: search "Miles Davis Kind of Blue" (artist-first) — returns correct album

🤖 Generated with [Claude Code](https://claude.com/claude-code)