### PR TITLE
feat: camera capture — point phone at album cover to get pricing

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+DISCOGS_TOKEN=               # from discogs.com/settings/developers
+EXCHANGE_RATE_API_KEY=       # from exchangerate-api.com
+EXCHANGE_RATE_CACHE_DURATION=86400000
+ANTHROPIC_API_KEY=           # from console.anthropic.com

--- a/app/api/identify/route.test.ts
+++ b/app/api/identify/route.test.ts
@@ -1,0 +1,154 @@
+const MOCK_TEXT_BLOCK = { type: 'text', text: 'Pink Floyd - The Dark Side of the Moon' };
+
+let mockCreate: jest.Mock;
+
+function makeRequest(file?: File): Request {
+  const formData = new FormData();
+  if (file) formData.append('image', file);
+  return new Request('http://localhost/api/identify', { method: 'POST', body: formData });
+}
+
+function makeFile(type = 'image/jpeg', size = 1024): File {
+  return new File([new ArrayBuffer(size)], 'cover.jpg', { type });
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env.ANTHROPIC_API_KEY = 'test-key';
+  mockCreate = jest.fn().mockResolvedValue({ content: [MOCK_TEXT_BLOCK] });
+  jest.doMock('@anthropic-ai/sdk', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({ messages: { create: mockCreate } })),
+  }));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('POST /api/identify', () => {
+  it('returns 200 and { query } when Claude identifies the album', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest(makeFile()));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ query: 'Pink Floyd - The Dark Side of the Moon' });
+  });
+
+  it('trims whitespace from Claude response', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: '  Pink Floyd - The Dark Side of the Moon  \n' }],
+    });
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest(makeFile()));
+
+    expect(await res.json()).toEqual({ query: 'Pink Floyd - The Dark Side of the Moon' });
+  });
+
+  it('calls Anthropic with model claude-haiku-4-5 and base64 image source', async () => {
+    const { POST } = await import('./route');
+    await POST(makeRequest(makeFile()));
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-haiku-4-5',
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.arrayContaining([
+              expect.objectContaining({ type: 'image', source: expect.objectContaining({ type: 'base64' }) }),
+            ]),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('includes cache_control ephemeral on the system prompt block', async () => {
+    const { POST } = await import('./route');
+    await POST(makeRequest(makeFile()));
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.arrayContaining([
+          expect.objectContaining({ cache_control: { type: 'ephemeral' } }),
+        ]),
+      }),
+    );
+  });
+
+  it('returns 200 + { query: "UNKNOWN" } when Claude returns "UNKNOWN"', async () => {
+    mockCreate.mockResolvedValueOnce({ content: [{ type: 'text', text: 'UNKNOWN' }] });
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest(makeFile()));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ query: 'UNKNOWN' });
+  });
+
+  it('returns 200 + { query: "UNKNOWN" } when Claude response has no text block', async () => {
+    mockCreate.mockResolvedValueOnce({ content: [] });
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest(makeFile()));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ query: 'UNKNOWN' });
+  });
+
+  it('returns 400 when no image field in FormData', async () => {
+    const { POST } = await import('./route');
+    const formData = new FormData();
+    formData.append('other', 'value');
+    const req = new Request('http://localhost/api/identify', { method: 'POST', body: formData });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when FormData is empty', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when Anthropic SDK throws', async () => {
+    mockCreate.mockRejectedValueOnce(new Error('API error'));
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest(makeFile()));
+
+    expect(res.status).toBe(500);
+  });
+
+  it('calls console.error on Anthropic SDK failure', async () => {
+    mockCreate.mockRejectedValueOnce(new Error('API error'));
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { POST } = await import('./route');
+    await POST(makeRequest(makeFile()));
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('passes media_type image/png through when file type is PNG', async () => {
+    const { POST } = await import('./route');
+    await POST(makeRequest(makeFile('image/png')));
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                source: expect.objectContaining({ media_type: 'image/png' }),
+              }),
+            ]),
+          }),
+        ]),
+      }),
+    );
+  });
+});

--- a/app/api/identify/route.ts
+++ b/app/api/identify/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import Anthropic from '@anthropic-ai/sdk';
+
+const anthropic = new Anthropic();
+
+const SYSTEM_PROMPT =
+  'You are a vinyl record identification assistant. When shown an image of a record album cover, ' +
+  'respond with ONLY the artist name and album title in this exact format: "Artist - Album Title". ' +
+  'If you cannot identify the record, respond with exactly: UNKNOWN. Do not include any other text.';
+
+export async function POST(req: Request) {
+  const formData = await req.formData();
+  const image = formData.get('image');
+
+  if (!image || !(image instanceof File)) {
+    return NextResponse.json({ error: 'No image provided' }, { status: 400 });
+  }
+
+  try {
+    const bytes = await image.arrayBuffer();
+    const base64 = Buffer.from(bytes).toString('base64');
+    const mediaType = (image.type || 'image/jpeg') as Anthropic.Base64ImageSource['media_type'];
+
+    const message = await anthropic.messages.create({
+      model: 'claude-haiku-4-5',
+      max_tokens: 100,
+      system: [
+        {
+          type: 'text',
+          text: SYSTEM_PROMPT,
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: mediaType,
+                data: base64,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const textBlock = message.content.find((block) => block.type === 'text') as Anthropic.TextBlock | undefined;
+    const query = textBlock ? textBlock.text.trim() : 'UNKNOWN';
+
+    return NextResponse.json({ query });
+  } catch (error) {
+    console.error('Failed to identify record:', error);
+    return NextResponse.json({ error: 'Failed to identify record' }, { status: 500 });
+  }
+}

--- a/app/search/components/CameraButton.test.ts
+++ b/app/search/components/CameraButton.test.ts
@@ -1,0 +1,170 @@
+import { handleCameraCapture } from './CameraButton';
+import { findRelease } from '@/app/search/search-service';
+import { ReleaseData } from '@/app/search/search-service';
+
+jest.mock('@/app/search/search-service', () => ({ findRelease: jest.fn() }));
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+
+const mockFindRelease = findRelease as jest.MockedFunction<typeof findRelease>;
+
+const MOCK_RELEASE: ReleaseData = {
+  image: 'https://example.com/cover.jpg',
+  title: 'The Dark Side of the Moon',
+  artists: ['Pink Floyd'],
+  year: 1973,
+  noOfTracks: 10,
+  noForSale: 42,
+  originalPriceSuggestion: null,
+  latestPriceSuggestion: 0,
+  genres: ['Rock'],
+  summary: 'A classic album.',
+  rating: { count: 1000, average: 4.9 },
+};
+
+function makeFile(size = 1024, type = 'image/jpeg'): File {
+  return new File([new ArrayBuffer(size)], 'cover.jpg', { type });
+}
+
+let onRecordSearch: jest.Mock;
+let setLoading: jest.Mock;
+let setError: jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  onRecordSearch = jest.fn();
+  setLoading = jest.fn();
+  setError = jest.fn();
+
+  jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ query: 'Pink Floyd - The Dark Side of the Moon' }),
+  } as Response);
+
+  mockFindRelease.mockResolvedValue(MOCK_RELEASE);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('handleCameraCapture', () => {
+  it('returns immediately without fetching when file is undefined', async () => {
+    await handleCameraCapture(undefined, onRecordSearch, setLoading, setError);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(setLoading).not.toHaveBeenCalled();
+  });
+
+  it('returns immediately without fetching when file is null', async () => {
+    await handleCameraCapture(null, onRecordSearch, setLoading, setError);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(setLoading).not.toHaveBeenCalled();
+  });
+
+  it('sets "too large" error and skips fetch when file exceeds 10 MB', async () => {
+    const bigFile = makeFile(10_485_761);
+
+    await handleCameraCapture(bigFile, onRecordSearch, setLoading, setError);
+
+    expect(setError).toHaveBeenCalledWith(expect.stringContaining('too large'));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to /api/identify with FormData containing image field', async () => {
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/identify',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(FormData),
+      }),
+    );
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = init.body as FormData;
+    expect(body.get('image')).toBeInstanceOf(File);
+  });
+
+  it('calls setLoading(true) at start and setLoading(false) at end on success', async () => {
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(setLoading.mock.calls[0]).toEqual([true]);
+    expect(setLoading.mock.calls[setLoading.mock.calls.length - 1]).toEqual([false]);
+  });
+
+  it('calls setLoading(false) after a fetch error', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network failure'));
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(setLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it('sets error and skips findRelease when API returns query "UNKNOWN"', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ query: 'UNKNOWN' }),
+    } as Response);
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(setError).toHaveBeenCalledWith(expect.stringContaining("Couldn't identify"));
+    expect(mockFindRelease).not.toHaveBeenCalled();
+  });
+
+  it('sets "Network error" and skips findRelease when fetch throws', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network failure'));
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(setError).toHaveBeenCalledWith(expect.stringContaining('Network error'));
+    expect(mockFindRelease).not.toHaveBeenCalled();
+  });
+
+  it('sets error and skips findRelease when response.ok is false', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({}),
+    } as Response);
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(setError).toHaveBeenCalled();
+    expect(mockFindRelease).not.toHaveBeenCalled();
+  });
+
+  it('sets error and skips findRelease when response body contains { error }', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ error: 'Something went wrong' }),
+    } as Response);
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(setError).toHaveBeenCalled();
+    expect(mockFindRelease).not.toHaveBeenCalled();
+  });
+
+  it('calls findRelease with the query returned by the identify API', async () => {
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(mockFindRelease).toHaveBeenCalledWith('Pink Floyd - The Dark Side of the Moon');
+  });
+
+  it('calls onRecordSearch with the ReleaseData from findRelease', async () => {
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(onRecordSearch).toHaveBeenCalledWith(MOCK_RELEASE);
+  });
+
+  it('sets "Couldn\'t find this record" error and skips onRecordSearch when findRelease throws', async () => {
+    mockFindRelease.mockRejectedValueOnce(new Error('Not found'));
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(setError).toHaveBeenCalledWith(expect.stringContaining("Couldn't find this record"));
+    expect(onRecordSearch).not.toHaveBeenCalled();
+  });
+});

--- a/app/search/components/CameraButton.test.ts
+++ b/app/search/components/CameraButton.test.ts
@@ -1,6 +1,5 @@
 import { handleCameraCapture } from './CameraButton';
-import { findRelease } from '@/app/search/search-service';
-import { ReleaseData } from '@/app/search/search-service';
+import { findRelease, ReleaseData } from '@/app/search/search-service';
 
 jest.mock('@/app/search/search-service', () => ({ findRelease: jest.fn() }));
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));

--- a/app/search/components/CameraButton.tsx
+++ b/app/search/components/CameraButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 import { CameraIcon } from '@heroicons/react/24/solid';
 import { findRelease, ReleaseData } from '@/app/search/search-service';
 
@@ -76,7 +76,7 @@ export default function CameraButton({ onRecordSearch }: CameraButtonProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>('');
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     setError('');
     handleCameraCapture(file, onRecordSearch, setLoading, setError);

--- a/app/search/components/CameraButton.tsx
+++ b/app/search/components/CameraButton.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { CameraIcon } from '@heroicons/react/24/solid';
+import { findRelease, ReleaseData } from '@/app/search/search-service';
+
+const MAX_FILE_SIZE = 10_485_760;
+
+export async function handleCameraCapture(
+  file: File | null | undefined,
+  onRecordSearch: (data: ReleaseData) => void,
+  setLoading: (loading: boolean) => void,
+  setError: (error: string) => void,
+) {
+  if (!file) return;
+
+  if (file.size > MAX_FILE_SIZE) {
+    setError('Image is too large — try a closer shot');
+    return;
+  }
+
+  setLoading(true);
+
+  let query: string;
+  try {
+    const formData = new FormData();
+    formData.append('image', file);
+
+    const res = await fetch('/api/identify', { method: 'POST', body: formData });
+
+    if (!res.ok) {
+      setError('Could not reach the server — try again');
+      setLoading(false);
+      return;
+    }
+
+    const body = await res.json();
+
+    if (body.error) {
+      setError('Could not reach the server — try again');
+      setLoading(false);
+      return;
+    }
+
+    query = body.query as string;
+  } catch {
+    setError('Network error — check your connection');
+    setLoading(false);
+    return;
+  }
+
+  if (query === 'UNKNOWN') {
+    setError("Couldn't identify this cover — try better lighting or search manually");
+    setLoading(false);
+    return;
+  }
+
+  try {
+    const data = await findRelease(query);
+    onRecordSearch(data);
+  } catch {
+    setError("Couldn't find this record in the database — try searching manually");
+    setLoading(false);
+    return;
+  }
+
+  setLoading(false);
+}
+
+interface CameraButtonProps {
+  onRecordSearch: (data: ReleaseData) => void;
+}
+
+export default function CameraButton({ onRecordSearch }: CameraButtonProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    setError('');
+    handleCameraCapture(file, onRecordSearch, setLoading, setError);
+    e.target.value = '';
+  };
+
+  return (
+    <div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={handleChange}
+      />
+      <button
+        type="button"
+        className="btn btn-primary flex items-center justify-center"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={loading}
+      >
+        {loading ? (
+          <span className="loading loading-spinner" />
+        ) : (
+          <CameraIcon className="h-5 w-5" />
+        )}
+      </button>
+      {error && <p className="text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -3,6 +3,7 @@
 import  React,  { useState } from "react";
 import AlbumTile from "@/app/search/components/AlbumTile";
 import LookUpForm from "@/app/search/components/RecordSearchForm";
+import CameraButton from "@/app/search/components/CameraButton";
 import { ReleaseData } from "./search-service";
 import { CurrencySelector } from "@/components/CurrencySelector";
 import { Currency, currencyOptions } from "@/types/currency";
@@ -33,6 +34,12 @@ export default function Search() {
         <h1 className="text-3xl md:text-4xl font-extrabold">Crate Mole</h1>
         This nifty little search is a companion for record collectors, to be used in the real world, just to allow you to dig those crates a little deeper.
         <LookUpForm onRecordSearch={handleRecordSearch} />
+        <div className="flex items-center gap-4">
+          <div className="flex-1 border-t border-base-300" />
+          <span className="text-sm text-base-content/50">or scan a cover</span>
+          <div className="flex-1 border-t border-base-300" />
+        </div>
+        <CameraButton onRecordSearch={handleRecordSearch} />
         {searchAttempted && (
           <AlbumTile 
             findRecordResponse={findRecordResponse} 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "crate-mole",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.2.0",
         "axios": "^1.6.8",
@@ -56,6 +57,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6154,6 +6175,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8175,6 +8209,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -8835,9 +8875,11 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.91.1",
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.2.0",
     "axios": "^1.6.8",


### PR DESCRIPTION
## What and why

Adds a camera input as a parallel entry point alongside the existing text search. Users in record stores can tap a camera button, point their phone at an album cover, and get pricing — no typing required.

The image is captured via `<input type="file" capture="environment">` (chosen over `getUserMedia` for Safari/iOS reliability), sent to a new `/api/identify` route, identified by Claude Haiku (vision), and the returned `"Artist - Title"` string is fed directly into the existing `findRelease` pipeline unchanged.

## Key decisions and trade-offs

- **`<input capture="environment">` over `getUserMedia`**: More reliable on iOS Safari; hands off to the OS camera sheet rather than managing a live viewfinder in-browser.
- **Claude Haiku**: Fast and cheap for a single-turn vision task; latency stays acceptable on mobile networks.
- **Prompt caching on system block**: The system prompt is stable across all requests — marking it `cache_control: ephemeral` amortises the token cost.
- **`handleCameraCapture` extracted as a pure async function**: Keeps all branching logic testable in a `node` Jest environment without rendering React, matching the project's existing test patterns.
- **Route returns `UNKNOWN` passthrough**: The `/api/identify` route does not interpret `UNKNOWN` — the client decides what error message to show, keeping the route simple and dumb.

## Files changed

| File | Change |
|------|--------|
| `app/api/identify/route.ts` | New POST route — accepts image, calls Claude Haiku, returns `{ query }` |
| `app/api/identify/route.test.ts` | 11 tests: happy path, whitespace trim, model/source assertions, cache_control, UNKNOWN, empty FormData, 400/500 |
| `app/search/components/CameraButton.tsx` | New client component + exported `handleCameraCapture` logic |
| `app/search/components/CameraButton.test.ts` | 13 tests covering all branches of `handleCameraCapture` |
| `app/search/page.tsx` | Renders `<CameraButton>` below the search form with divider |
| `.env.local.example` | Added `ANTHROPIC_API_KEY` entry |

## Test plan

- [x] `npm test` — all 55 tests pass, no existing tests broken
- [ ] Manual on mobile: tap camera button → OS camera opens → photo of recognisable cover → AlbumTile renders with pricing
- [ ] Manual on mobile: photo of wall → "Couldn't identify this cover" error; form still usable
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)