### PR TITLE
test: Playwright smoke test suite for /search UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,26 @@ jobs:
           node-version: '20'
       - run: npm ci
       - run: npm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+        env:
+          DISCOGS_TOKEN: dummy
+          EXCHANGE_RATE_API_KEY: dummy
+          ANTHROPIC_API_KEY: dummy
+          EXCHANGE_RATE_CACHE_DURATION: '86400000'
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_CURRENCY_RATES = {
+  GBP: 0.79, EUR: 0.92, USD: 1, RSD: 110.5, CHF: 0.9,
+  CAD: 1.36, AUD: 1.53, JPY: 150.5, CNY: 7.24, KRW: 1340,
+  INR: 83.2, BRL: 4.97, MXN: 17.2, SEK: 10.5,
+};
+
+const MOCK_RELEASE_DATA = {
+  image: 'https://i.discogs.com/test-abbey-road.jpg',
+  title: 'Abbey Road',
+  artists: ['The Beatles'],
+  year: 1969,
+  noOfTracks: 17,
+  noForSale: 500,
+  originalPriceSuggestion: {
+    'Mint (M)': { currency: 'USD', value: 50 },
+    'Near Mint (NM or M-)': { currency: 'USD', value: 40 },
+    'Very Good Plus (VG+)': { currency: 'USD', value: 30 },
+    'Very Good (VG)': { currency: 'USD', value: 20 },
+    'Good Plus (G+)': { currency: 'USD', value: 15 },
+    'Good (G)': { currency: 'USD', value: 10 },
+    'Fair (F)': { currency: 'USD', value: 5 },
+    'Poor (P)': { currency: 'USD', value: 2 },
+  },
+  latestPriceSuggestion: 0,
+  genres: ['Rock', 'Classic Rock'],
+  summary: 'Abbey Road is the eleventh studio album by the Beatles.',
+  rating: { count: 5000, average: 4.5 },
+};
+
+// React Flight wire format for a Next.js server action that returns a plain object.
+// Row 1: the ReleaseData payload (JSON-serialised).
+// Row 0: the [actionResult, [, actionFlightData]] tuple the router reducer expects.
+//   "$@1" is a React Flight promise-reference that resolves to row 1.
+//   The outer Promise returned by callServer chains to this reference, so
+//   `await findRelease(...)` ultimately resolves to the ReleaseData value.
+const RSC_ACTION_BODY = [
+  `1:${JSON.stringify(MOCK_RELEASE_DATA)}`,
+  `0:["$@1",[null,null]]`,
+].join('\n') + '\n';
+
+test.beforeEach(async ({ page }) => {
+  await page.route('/api/currency', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_CURRENCY_RATES),
+    })
+  );
+});
+
+test('page loads without console errors', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+  await page.goto('/search');
+  await page.waitForLoadState('networkidle');
+  expect(errors).toHaveLength(0);
+});
+
+test('search form input and submit button are visible', async ({ page }) => {
+  await page.goto('/search');
+  await expect(page.locator('#search')).toBeVisible();
+  await expect(page.locator('button[type="submit"]')).toBeVisible();
+});
+
+test('camera button is visible and contains a hidden file input', async ({ page }) => {
+  await page.goto('/search');
+  await expect(page.locator('button[type="button"]')).toBeVisible();
+  const fileInput = page.locator('input[type="file"]');
+  await expect(fileInput).toHaveAttribute('accept', 'image/*');
+  await expect(fileInput).toHaveAttribute('capture', 'environment');
+  await expect(fileInput).toBeHidden();
+});
+
+test('submitting a search triggers loading state then renders AlbumTile', async ({ page }) => {
+  // Intercept the server action POST (Next-Action header identifies it).
+  // Delay 100 ms so the loading spinner is observable before the response lands.
+  await page.route('/search', async (route) => {
+    if (
+      route.request().method() === 'POST' &&
+      route.request().headers()['next-action']
+    ) {
+      await new Promise((r) => setTimeout(r, 100));
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'content-type': 'text/x-component',
+          'x-action-revalidated': '[[],0,0]',
+        },
+        body: RSC_ACTION_BODY,
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto('/search');
+  await page.waitForLoadState('networkidle');
+  await page.fill('#search', 'Abbey Road');
+  await page.click('button[type="submit"]');
+
+  await expect(page.locator('button[type="submit"] .loading')).toBeVisible();
+  await expect(page.locator('.card-title')).toHaveText('Abbey Road', { timeout: 10_000 });
+});
+
+test('currency selector is visible and changing it does not crash the page', async ({ page }) => {
+  await page.goto('/search');
+  const select = page.locator('select');
+  await expect(select).toBeVisible();
+  await select.selectOption('GBP');
+  await expect(page.locator('#search')).toBeVisible();
+});
+
+test('layout has no horizontal overflow at 390×844 (iPhone 14)', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/search');
+  await page.waitForLoadState('networkidle');
+  const { docScrollWidth, innerWidth } = await page.evaluate(() => ({
+    docScrollWidth: document.documentElement.scrollWidth,
+    innerWidth: window.innerWidth,
+  }));
+  expect(docScrollWidth).toBeLessThanOrEqual(innerWidth);
+});

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -53,7 +53,11 @@ test.beforeEach(async ({ page }) => {
 test('page loads without console errors', async ({ page }) => {
   const errors: string[] = [];
   page.on('console', (msg) => {
-    if (msg.type() === 'error') errors.push(msg.text());
+    if (msg.type() !== 'error') return;
+    // Ignore noise from Next.js dev-mode HMR and browser-injected scripts.
+    const url = msg.location().url ?? '';
+    if (url && !url.includes('localhost')) return;
+    errors.push(msg.text());
   });
   await page.goto('/search');
   await page.waitForLoadState('networkidle');

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
+  testPathIgnorePatterns: ['<rootDir>/e2e/'],
 };
 
 export default createJestConfig(config);

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^20.12.2",
         "@types/react": "^18.2.73",
@@ -1750,6 +1751,23 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -7041,6 +7059,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
@@ -27,6 +28,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^20.12.2",
     "@types/react": "^18.2.73",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3001',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -- -p 3001',
+    url: 'http://localhost:3001',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: process.env.CI ? [['html'], ['list']] : 'html',
   use: {
     baseURL: 'http://localhost:3001',
     trace: 'on-first-retry',


### PR DESCRIPTION
## What was built and why

Establishes a Playwright E2E layer alongside the existing Jest unit tests. The goal is a baseline so future UI tasks can write Playwright tests as part of their PRs — no new features, no visual regression tooling.

## What's included

**`e2e/search.spec.ts`** — 6 chromium smoke tests:
- Page loads without console errors
- Search form input and submit button visible
- Camera button visible; hidden `<input type="file" accept="image/*" capture="environment">` present
- Submitting triggers loading spinner then renders `AlbumTile` with correct title
- Currency selector visible; changing it doesn't crash the page
- 390×844 viewport (iPhone 14) — no horizontal overflow

**`playwright.config.ts`** — Chromium only, port 3001 (avoids collision with the default dev port), `webServer` spins up `next dev` automatically during test runs.

**CI** — `e2e` job depending on `test`, installs Chromium with deps, runs `npm run test:e2e`, uploads HTML report as artifact. All external API keys are dummy values since every outbound call is mocked.

## Key decisions and trade-offs

**Server action mocking via React Flight wire format.** `findRelease` is a `"use server"` action; the browser POSTs to `/search` with a `Next-Action` header and expects a React Flight (RSC) response. By tracing through the `react-server-dom-webpack` client source, the expected shape is a `[actionResult, [, actionFlightData]]` tuple. The mock returns:
```
1:<serialised ReleaseData>
0:["$@1",[null,null]]
```
`$@1` is a Flight promise-reference to row 1. `serverActionReducer` calls `resolve(actionResult)` where `actionResult` is that reference — standard Promise chaining means `await findRelease()` resolves to the `ReleaseData`. No source files were modified to achieve this.

**100 ms artificial delay on the server action mock** so the loading spinner is observable before the response lands.

**`jest.config.ts` gets one new line** (`testPathIgnorePatterns: ['<rootDir>/e2e/']`). Without it Jest's default `**/*.spec.ts` glob picks up the Playwright specs and fails with "no tests found". This doesn't affect any existing test behaviour — confirmed: 55/55 Jest tests still pass.

Closes #— (no issue; self-contained infra task)