### PR TITLE
docs: update README and CLAUDE.md to reflect current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ npm run dev       # Start dev server (localhost:3000)
 npm run build     # Production build
 npm run lint      # ESLint via next lint
 npm test          # Run Jest test suite
+npm run test:e2e  # Run Playwright e2e suite (starts dev server automatically)
 ```
 
 Copy `.env.local.example` to `.env.local` before running locally:
@@ -25,7 +26,7 @@ EXCHANGE_RATE_CACHE_DURATION=86400000
 
 ### Request flow
 
-1. `RecordSearchForm` (client) calls the `findRelease` server action in `app/search/search-service.ts`
+1. `app/page.tsx` (client) renders `LookUpForm` and `CameraButton`; both call the `findRelease` server action in `app/search/search-service.ts`
 2. `findRelease` makes sequential Discogs calls:
    - `searchDiscogs` → finds matching releases, takes the first result with a `master_id`
    - `getDiscogsMasterRelease(master_id)` → gets the canonical master release
@@ -59,6 +60,8 @@ jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
 ```
 
 `ConditionValues` fixture objects must include all 8 `Condition` enum keys, each with `{ currency: string; value: number }`.
+
+Playwright e2e tests live in `e2e/search.spec.ts` and exercise the full UI at `/`. Run them with `npm run test:e2e` — the Playwright config starts the dev server automatically. The server-action intercept in those tests targets `'/'` (not `'/search'`) because `findRelease` is a server action and Next.js posts it to the current page URL. When mocking components in Jest render tests, use named function expressions (`function Foo() { return <div />; }`) rather than anonymous arrows to satisfy the `react/display-name` ESLint rule.
 
 ### Styling
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crate Mole
 
-A vinyl record companion tool. Search any album by title (and optionally artist) to get pricing data, condition breakdowns, ratings, and a Wikipedia summary — all in one place.
+A vinyl pricing companion for record collectors. Point your phone at an album cover — or type a search — to get Discogs price suggestions by condition, alongside ratings, genre tags, album art, and a Wikipedia summary.
 
 Live at: https://unwave.net
 
@@ -10,57 +10,58 @@ Built by William (william@thewhisk.dev)
 
 ## What it does
 
-1. User enters an album title (e.g. "Dark Side of the Moon, Pink Floyd")
-2. The app queries the Discogs API to find the master release
-3. Returns: album art, tracklist count, copies for sale, price suggestions by condition (Mint → Good), ratings, genres
-4. Fetches a Wikipedia summary for the album
-5. Converts prices to the user's selected currency via ExchangeRate-API
+1. **Camera scan** — point your phone at an album cover; a vision model identifies the record automatically
+2. **Text search** — type an album title, artist, or both (e.g. "Dark Side of the Moon Pink Floyd")
+3. The app queries Discogs to find the master release
+4. Returns: album art, tracklist count, copies for sale, price suggestions by condition (Mint → Poor), ratings, genres
+5. Fetches a Wikipedia summary for the album
+6. Converts prices to the user's selected currency via ExchangeRate-API
 
 ## Stack
 
-- **Next.js 14** (App Router, TypeScript)
+- **Next.js 14** (App Router, TypeScript, server actions)
 - **TailwindCSS** + **DaisyUI** for styling
 - **Discogs API** — record database, marketplace pricing, ratings
+- **Anthropic API** — vision model for album cover identification
 - **Wikipedia npm package** — album summaries
 - **ExchangeRate-API** — currency conversion (cached 24h)
-- **Jest** (via `next/jest`) — test suite
+- **Jest** (via `next/jest`) + **Playwright** — test suite
 
 ## Local development
 
 ```bash
 npm install
-npm run dev     # localhost:3000
-npm test        # run Jest suite
+npm run dev         # localhost:3000
+npm test            # Jest unit tests
+npm run test:e2e    # Playwright end-to-end tests
 ```
 
-Copy `.env.local.example` to `.env.local` and fill in the three required values:
+Copy `.env.local.example` to `.env.local` and fill in the required values:
 
 ```
-DISCOGS_TOKEN=           # from discogs.com/settings/developers
-EXCHANGE_RATE_API_KEY=   # from exchangerate-api.com
+DISCOGS_TOKEN=               # from discogs.com/settings/developers
+EXCHANGE_RATE_API_KEY=       # from exchangerate-api.com
 EXCHANGE_RATE_CACHE_DURATION=86400000
+ANTHROPIC_API_KEY=           # from console.anthropic.com
 ```
 
 ## Project structure
 
 ```
 app/
-  page.tsx                  # Root — renders the search form
+  page.tsx                  # Root — search form + camera button + results
   search/
-    page.tsx                # /search route (alternate entry point)
-    search-service.ts       # Server action: orchestrates Discogs + Wiki + currency
+    search-service.ts       # Server action: orchestrates Discogs + Wiki
     components/
-      RecordSearchForm.tsx  # Search input form
+      RecordSearchForm.tsx  # Text search input
+      CameraButton.tsx      # Camera capture → vision model → search
       AlbumTile.tsx         # Result card
   api/
     currency/route.ts       # Exchange rate endpoint (keeps API key server-side)
-    discogs/
-      search/route.ts       # Discogs search proxy
-      master/route.ts       # Discogs master release proxy
+    identify/route.ts       # Album cover identification (Anthropic vision)
 libs/
   discogs.ts                # Discogs API client
   wiki.ts                   # Wikipedia client
-  seo.tsx                   # SEO tag helpers
 types/
   discogs.ts                # Discogs API types
   currency.ts               # Currency types
@@ -68,6 +69,7 @@ types/
 
 ## Key design notes
 
-- The Discogs token and ExchangeRate API key are never exposed to the browser — all external API calls go through Next.js server actions or API routes.
-- Exchange rates are cached for 24 hours (`EXCHANGE_RATE_CACHE_DURATION`) to avoid hammering the free tier.
-- Currency selection is stored in React context (`app/currency-provider.tsx`) so it persists across searches without a page reload.
+- All external API calls (Discogs, Anthropic, ExchangeRate) go through Next.js server actions or API routes — tokens are never sent to the browser.
+- Exchange rates are cached for 24 hours (`EXCHANGE_RATE_CACHE_DURATION`) to stay within the free tier.
+- Currency selection is stored in React state in `app/page.tsx` and passed down, so it persists across searches without a page reload.
+- `/search` permanently redirects to `/` — the full UI (text search + camera) lives at the root.


### PR DESCRIPTION
## Summary

Both docs were stale after the camera feature was shipped and the `/search` route was collapsed into root.

**README.md:**
- Added camera scan to the "What it does" section
- Added Anthropic API to the stack
- Added `npm run test:e2e` and `ANTHROPIC_API_KEY` to the local dev section
- Removed the now-deleted `search/page.tsx` from the project structure; added `CameraButton.tsx` and `identify/route.ts`
- Added a note that `/search` redirects to `/`

**CLAUDE.md:**
- Added `npm run test:e2e` to the Commands section
- Fixed the stale request-flow step that named `RecordSearchForm` as the entry point — it is now `app/page.tsx` rendering `LookUpForm` and `CameraButton`
- Added a Playwright e2e blurb explaining file location, the reason the server-action intercept targets `/`, and the `react/display-name` rule for component mocks in Jest render tests