### PR TITLE
feat: make Wikipedia lookup failures non-fatal in search

### DIFF
--- a/app/search/components/AlbumTile.tsx
+++ b/app/search/components/AlbumTile.tsx
@@ -59,8 +59,7 @@ export default function AlbumTile(props: AlbumTileProps) {
             </div>
         </div>
         <div className="mt-4">
-            {/* Album description */}
-            <p>{props.findRecordResponse.summary}</p>
+            {props.findRecordResponse.summary && <p>{props.findRecordResponse.summary}</p>}
         </div></>
     
     )

--- a/app/search/search-service.test.ts
+++ b/app/search/search-service.test.ts
@@ -169,6 +169,22 @@ describe('findRelease', () => {
     expect(mockGetWikiSummary).not.toHaveBeenCalled();
   });
 
+  it('sets summary to null when searchWiki throws', async () => {
+    mockSearchWiki.mockRejectedValueOnce(new Error('wiki credentials error'));
+
+    const result = await findRelease('Test Album Artist A');
+
+    expect(result.summary).toBeNull();
+  });
+
+  it('sets summary to null when getWikiSummary throws', async () => {
+    mockGetWikiSummary.mockRejectedValueOnce(new Error('wiki summary error'));
+
+    const result = await findRelease('Test Album Artist A');
+
+    expect(result.summary).toBeNull();
+  });
+
   it('calls revalidatePath("/") on success', async () => {
     await findRelease('Test Album Artist A');
 

--- a/app/search/search-service.ts
+++ b/app/search/search-service.ts
@@ -15,7 +15,7 @@ export interface ReleaseData {
     originalPriceSuggestion: ConditionValues;
     latestPriceSuggestion: number;
     genres: string[];
-    summary: string;
+    summary: string | null;
     rating: {
         count: number, 
         average: number
@@ -71,10 +71,14 @@ export async function findRelease(query: string): Promise<ReleaseData> {
          console.log("No image URI found");
     }
 
-    const wikiResponse = await searchWiki(`${discogsMaster.title}, ${discogsMaster.artists[0].name}, album`);
-    if (wikiResponse.results && wikiResponse.results.length > 0 && wikiResponse.results.length > 0) {
-        const wikiTitle = wikiResponse.results[0].title;
-        wikiSource = (await getWikiSummary(wikiTitle)).extract;
+    try {
+        const wikiResponse = await searchWiki(`${discogsMaster.title}, ${discogsMaster.artists[0].name}, album`);
+        if (wikiResponse.results && wikiResponse.results.length > 0) {
+            const wikiTitle = wikiResponse.results[0].title;
+            wikiSource = (await getWikiSummary(wikiTitle)).extract;
+        }
+    } catch (error) {
+        console.warn('Wikipedia lookup failed, continuing without summary:', error);
     }
    
     


### PR DESCRIPTION
## What and why

Wikipedia credential errors were causing the entire `findRelease()` call to fail and show a \"Couldn't find release\" error to the user. Wikipedia data (the album summary) is purely supplementary — if it's unavailable, the Discogs pricing, ratings, and metadata should still be returned.

## Changes

- `search-service.ts`: Wrapped `searchWiki` / `getWikiSummary` calls in a try/catch that logs a warning and leaves `summary` as `null` on failure. Also corrected the `ReleaseData.summary` type from `string` to `string | null` (it was already nullable in practice).
- `AlbumTile.tsx`: Added a null guard so the summary `<p>` is omitted entirely when `summary` is null, rather than rendering an empty paragraph.
- Tests: Two new test cases cover both failure modes (`searchWiki` throws; `getWikiSummary` throws), following red → green.

## Key decision

The try/catch lives in `search-service.ts`, not in `libs/wiki.ts`. The wiki library re-throws errors deliberately — swallowing them there would hide failures in any future caller. Resilience to optional-data failures is a concern of the orchestrating service, not the data-fetching library.