### PR TITLE
fix: compress camera images client-side to avoid Vercel payload limit

### DIFF
--- a/app/search/components/CameraButton.render.test.tsx
+++ b/app/search/components/CameraButton.render.test.tsx
@@ -8,6 +8,9 @@ import CameraButton from './CameraButton';
 
 jest.mock('@/app/search/search-service', () => ({ findRelease: jest.fn() }));
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+jest.mock('./resize-image', () => ({
+  resizeImage: jest.fn().mockResolvedValue(new Blob(['tiny'], { type: 'image/jpeg' })),
+}));
 
 function makeFile(size = 1024): File {
   return new File([new ArrayBuffer(size)], 'cover.jpg', { type: 'image/jpeg' });

--- a/app/search/components/CameraButton.test.ts
+++ b/app/search/components/CameraButton.test.ts
@@ -3,6 +3,9 @@ import { findRelease, ReleaseData } from '@/app/search/search-service';
 
 jest.mock('@/app/search/search-service', () => ({ findRelease: jest.fn() }));
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+jest.mock('./resize-image', () => ({
+  resizeImage: jest.fn().mockResolvedValue(new Blob(['tiny'], { type: 'image/jpeg' })),
+}));
 
 const mockFindRelease = findRelease as jest.MockedFunction<typeof findRelease>;
 
@@ -61,13 +64,21 @@ describe('handleCameraCapture', () => {
     expect(setLoading).not.toHaveBeenCalled();
   });
 
-  it('sets "too large" error and skips fetch when file exceeds 10 MB', async () => {
-    const bigFile = makeFile(10_485_761);
+  it('sets "too large" error and skips fetch when file exceeds 50 MB', async () => {
+    const bigFile = makeFile(52_428_801);
 
     await handleCameraCapture(bigFile, onRecordSearch, setLoading, setError);
 
     expect(setError).toHaveBeenCalledWith(expect.stringContaining('too large'));
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('compresses image via resizeImage before uploading', async () => {
+    const { resizeImage } = await import('./resize-image');
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(resizeImage).toHaveBeenCalledWith(expect.any(File));
   });
 
   it('POSTs to /api/identify with FormData containing image field', async () => {

--- a/app/search/components/CameraButton.tsx
+++ b/app/search/components/CameraButton.tsx
@@ -3,8 +3,9 @@
 import { ChangeEvent, useRef, useState } from 'react';
 import { CameraIcon } from '@heroicons/react/24/solid';
 import { findRelease, ReleaseData } from '@/app/search/search-service';
+import { resizeImage } from './resize-image';
 
-const MAX_FILE_SIZE = 10_485_760;
+const MAX_FILE_SIZE = 52_428_800; // 50 MB — hard cap before canvas resize
 
 export async function handleCameraCapture(
   file: File | null | undefined,
@@ -23,8 +24,10 @@ export async function handleCameraCapture(
 
   let query: string;
   try {
+    const resized = await resizeImage(file);
+    const compressed = new File([resized], file.name, { type: 'image/jpeg' });
     const formData = new FormData();
-    formData.append('image', file);
+    formData.append('image', compressed);
 
     const res = await fetch('/api/identify', { method: 'POST', body: formData });
 

--- a/app/search/components/resize-image.ts
+++ b/app/search/components/resize-image.ts
@@ -1,0 +1,30 @@
+const MAX_DIMENSION = 1024;
+const QUALITY = 0.8;
+
+export async function resizeImage(file: File): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      const scale = Math.min(1, MAX_DIMENSION / Math.max(img.width, img.height));
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(img.width * scale);
+      canvas.height = Math.round(img.height * scale);
+      canvas.getContext('2d')!.drawImage(img, 0, 0, canvas.width, canvas.height);
+      canvas.toBlob(
+        (blob) => (blob ? resolve(blob) : reject(new Error('toBlob failed'))),
+        'image/jpeg',
+        QUALITY,
+      );
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Image load failed'));
+    };
+
+    img.src = url;
+  });
+}


### PR DESCRIPTION
## Summary

- Camera uploads were hitting Vercel's 4.5 MB serverless function payload limit because `MAX_FILE_SIZE` was set to 10 MB — phone photos between 4.5–10 MB passed the client guard but were rejected by Vercel with `FUNCTION_PAYLOAD_TOO_LARGE`
- Added a `resizeImage` utility that uses a canvas to scale images down to a max of 1024px on the longest edge and re-encodes as JPEG at 0.8 quality, bringing typical phone photos from 3–8 MB to ~150–400 KB
- `handleCameraCapture` now compresses every image before building the `FormData`, so the payload is always well within Vercel's limit
- `MAX_FILE_SIZE` raised to 50 MB as a hard cap against truly absurd inputs (e.g. someone selecting a video)

## Test plan

- [x] Jest unit tests updated to mock `./resize-image` in both the logic test and render test
- [x] New test asserts `resizeImage` is called with the file before fetch
- [x] "too large" threshold test updated to 50 MB
- [x] All 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)