### PR TITLE
ci: close validation gaps (lint, tsc, build, error e2e, branch protection)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,30 @@ jobs:
           node-version: '20'
       - run: npm ci
       - run: npm test
+      - run: npm run lint
+      - run: npx tsc --noEmit
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+        env:
+          DISCOGS_TOKEN: dummy
+          EXCHANGE_RATE_API_KEY: dummy
+          ANTHROPIC_API_KEY: dummy
+          EXCHANGE_RATE_CACHE_DURATION: '86400000'
+          NEXT_PUBLIC_SENTRY_DSN: ''
+          NEXT_PUBLIC_AXIOM_TOKEN: ''
+          NEXT_PUBLIC_AXIOM_DATASET: ''
 
   e2e:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, build]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -118,6 +118,26 @@ test('currency selector is visible and changing it does not crash the page', asy
   await expect(page.locator('#search')).toBeVisible();
 });
 
+test('search shows error message when server action fails', async ({ page }) => {
+  await page.route('/', async (route) => {
+    if (
+      route.request().method() === 'POST' &&
+      route.request().headers()['next-action']
+    ) {
+      await route.abort('failed');
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  await page.fill('#search', 'nonexistent album');
+  await page.click('button[type="submit"]');
+
+  await expect(page.locator('text=Couldn\'t find release')).toBeVisible({ timeout: 5_000 });
+});
+
 test('layout has no horizontal overflow at 390×844 (iPhone 14)', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/');

--- a/libs/discogs.test.ts
+++ b/libs/discogs.test.ts
@@ -2,6 +2,7 @@ jest.mock('next-axiom', () => ({ log: { error: jest.fn(), info: jest.fn() } }));
 
 import { log } from 'next-axiom';
 import { getDiscogsMasterRelease, searchDiscogs, getPriceSuggestion, getRating } from './discogs';
+import type { DiscogsItem } from '@/types/discogs';
 
 const mockLog = log as any;
 
@@ -40,7 +41,7 @@ describe('getDiscogsMasterRelease', () => {
 
 describe('searchDiscogs', () => {
   it('returns the parsed JSON response', async () => {
-    const mockResults = { results: [], pagination: { page: 1, pages: 1, per_page: 10, items: 0, urls: {} } };
+    const mockResults = { results: [] as DiscogsItem[], pagination: { page: 1, pages: 1, per_page: 10, items: 0, urls: {} } };
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       json: jest.fn().mockResolvedValueOnce(mockResults),
     });


### PR DESCRIPTION
## Summary

- Adds `npm run lint` and `npx tsc --noEmit` steps to the `test` CI job — ESLint violations and TypeScript errors are now enforced on every PR
- Adds a parallel `build` CI job running `npm run build` — catches production build failures before Vercel deploys
- Updates the `e2e` job to require both `test` and `build` to pass first
- Adds an e2e test for the search error state: aborts the server action POST to simulate a network failure and asserts "Couldn't find release" is shown
- Fixes an implicit-any TypeScript error in `libs/discogs.test.ts` (surfaced by adding `tsc` to CI)

After merging, branch protection will be configured on main to require all three CI jobs to pass before a PR can be merged.

## Key decisions

The error state e2e test uses `route.abort('failed')` rather than a 500 response. A 500 with a non-RSC content-type causes Next.js's `fetchServerAction` to silently resolve with `undefined` instead of rejecting — only a genuine network-level failure propagates through to the form's `catch` block.

The `build` job runs in parallel with `test` rather than sequentially, keeping the critical path as short as possible.