### PR TITLE
chore: enforce lint warnings as errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,6 @@
   },
   "rules": {
     // Your specific rules.
-    "no-unused-vars": "warn"
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }]
   }
 }

--- a/app/api/currency/route.ts
+++ b/app/api/currency/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
 let rates: { [currency: string]: number } | null = null;
 let cacheTimestamp: number | null = null;
 
-export async function GET(req: Request | NextRequest) {
+export async function GET(_req: Request) {
     const now = Date.now();
     
     if (rates && cacheTimestamp && now - cacheTimestamp < Number(process.env.EXCHANGE_RATE_CACHE_DURATION)) {

--- a/app/search/components/AlbumTile.tsx
+++ b/app/search/components/AlbumTile.tsx
@@ -14,7 +14,7 @@ interface AlbumTileProps {
 
 export default function AlbumTile(props: AlbumTileProps) {
 
-    const {rates, loading} = useCurrency();
+    const { rates } = useCurrency();
     
     const mintPrice = props.findRecordResponse.originalPriceSuggestion[Condition.Mint].value;
     const goodPrice = props.findRecordResponse.originalPriceSuggestion[Condition.VeryGood].value;

--- a/app/search/components/CameraButton.tsx
+++ b/app/search/components/CameraButton.tsx
@@ -9,9 +9,9 @@ const MAX_FILE_SIZE = 52_428_800; // 50 MB — hard cap before canvas resize
 
 export async function handleCameraCapture(
   file: File | null | undefined,
-  onRecordSearch: (data: ReleaseData) => void,
-  setLoading: (loading: boolean) => void,
-  setError: (error: string) => void,
+  onRecordSearch: (_data: ReleaseData) => void,
+  setLoading: (_loading: boolean) => void,
+  setError: (_error: string) => void,
 ) {
   if (!file) return;
 
@@ -71,7 +71,7 @@ export async function handleCameraCapture(
 }
 
 interface CameraButtonProps {
-  onRecordSearch: (data: ReleaseData) => void;
+  onRecordSearch: (_data: ReleaseData) => void;
 }
 
 export default function CameraButton({ onRecordSearch }: CameraButtonProps) {

--- a/app/search/components/RecordSearchForm.tsx
+++ b/app/search/components/RecordSearchForm.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { MagnifyingGlassIcon } from '@heroicons/react/24/solid';
 
 interface LookUpFormProps {
-    onRecordSearch: (findRecordResponse: ReleaseData) => void;
+    onRecordSearch: (_findRecordResponse: ReleaseData) => void;
   }
 
   interface FormData {
@@ -15,7 +15,7 @@ interface LookUpFormProps {
 
   export default function LookUpForm({onRecordSearch}: LookUpFormProps) {
     const [loading, setLoading] = useState(false);
-    const { register, handleSubmit, reset, formState: { errors }, setError } = useForm<FormData>({reValidateMode: 'onSubmit'});
+    const { register, handleSubmit, formState: { errors }, setError } = useForm<FormData>({reValidateMode: 'onSubmit'});
   
     const onSubmit: SubmitHandler<FormData> = async (data) =>{
 

--- a/components/CurrencySelector.tsx
+++ b/components/CurrencySelector.tsx
@@ -2,7 +2,7 @@ import { Currency, currencyOptions } from "@/types/currency";
 import React from "react";
 
 interface CurrencySelectorProps {
-    onCurrencyChange: (currency: Currency) => void; // Only need to notify the parent about the selected currency
+    onCurrencyChange: (_currency: Currency) => void;
   }
 
 export const CurrencySelector: React.FC<CurrencySelectorProps> = ({ onCurrencyChange }) => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint --max-warnings 0",
     "test": "jest",
     "test:e2e": "playwright test"
   },


### PR DESCRIPTION
## Summary

- Adds `--max-warnings 0` to the `lint` script — any ESLint warning now fails CI
- Configures `no-unused-vars` with `argsIgnorePattern` and `varsIgnorePattern` for `^_` so intentionally-unused parameters can be signalled with an `_` prefix
- Clears all 9 pre-existing warnings across 5 files:
  - `app/api/currency/route.ts` — removed unused `NextRequest` import, renamed `req` → `_req`
  - `app/search/components/AlbumTile.tsx` — removed `loading` from `useCurrency()` destructure
  - `app/search/components/CameraButton.tsx` — prefixed 4 callback param names in type signatures with `_`
  - `app/search/components/RecordSearchForm.tsx` — prefixed callback param name, removed `reset` from `useForm()` destructure
  - `components/CurrencySelector.tsx` — prefixed callback param name with `_`

## Key decisions

The `_` prefix pattern is needed for parameter names in function type signatures (e.g. `onRecordSearch: (_data: ReleaseData) => void`) — these are purely documentary and can't be removed, but ESLint still flags them without the ignore pattern configured.