### PR TITLE
docs: document route.abort pattern for e2e server action error mocking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
 
 `ConditionValues` fixture objects must include all 8 `Condition` enum keys, each with `{ currency: string; value: number }`.
 
-Playwright e2e tests live in `e2e/search.spec.ts` and exercise the full UI at `/`. Run them with `npm run test:e2e` — the Playwright config starts the dev server automatically. The server-action intercept in those tests targets `'/'` (not `'/search'`) because `findRelease` is a server action and Next.js posts it to the current page URL. When mocking components in Jest render tests, use named function expressions (`function Foo() { return <div />; }`) rather than anonymous arrows to satisfy the `react/display-name` ESLint rule.
+Playwright e2e tests live in `e2e/search.spec.ts` and exercise the full UI at `/`. Run them with `npm run test:e2e` — the Playwright config starts the dev server automatically. The server-action intercept in those tests targets `'/'` (not `'/search'`) because `findRelease` is a server action and Next.js posts it to the current page URL. To simulate a server action failure, use `route.abort('failed')` — a `route.fulfill({ status: 500 })` response is silently resolved by Next.js's `fetchServerAction` rather than rejected, so the form's `catch` block never runs. When mocking components in Jest render tests, use named function expressions (`function Foo() { return <div />; }`) rather than anonymous arrows to satisfy the `react/display-name` ESLint rule.
 
 ### Styling
 


### PR DESCRIPTION
Adds one sentence to the Testing section of CLAUDE.md documenting that `route.abort` must be used to simulate server action failures in Playwright tests — a 500 response is silently resolved by Next.js rather than rejected.