### PR TITLE
feat: condition slider for per-quality price estimate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ All Discogs and Wikipedia calls happen server-side — the `DISCOGS_TOKEN` is ne
 
 ### Currency
 
-`CurrencyProvider` (`app/currency-provider.tsx`) fetches exchange rates from `/api/currency` on app load and exposes them via the `useCurrency()` hook. The `/api/currency` route (Route Handler) caches rates in memory for `EXCHANGE_RATE_CACHE_DURATION` ms to stay within the ExchangeRate-API free tier. `AlbumTile` converts Discogs USD prices to the user's selected currency at render time.
+`CurrencyProvider` (`app/currency-provider.tsx`) fetches exchange rates from `/api/currency` on app load and exposes them via the `useCurrency()` hook. The `/api/currency` route (Route Handler) caches rates in memory for `EXCHANGE_RATE_CACHE_DURATION` ms to stay within the ExchangeRate-API free tier. `ConditionSlider` (`app/search/components/ConditionSlider.tsx`) converts Discogs USD prices to the user's selected currency at render time and lets the user slide between conditions (Poor → Mint), defaulting to Very Good+.
 
 ### Key types
 

--- a/app/search/components/AlbumTile.tsx
+++ b/app/search/components/AlbumTile.tsx
@@ -3,9 +3,8 @@
 import Image from 'next/image';
 import { ReleaseData } from '../search-service';
 import StarRating from '@/components/StarRating';
-import { useCurrency } from '@/app/currency-provider';
-import { Currency, currencyOptions } from '@/types/currency';
-import { Condition } from '@/types/discogs';
+import { Currency } from '@/types/currency';
+import ConditionSlider from './ConditionSlider';
 
 interface AlbumTileProps {
     findRecordResponse: ReleaseData
@@ -13,26 +12,13 @@ interface AlbumTileProps {
   }
 
 export default function AlbumTile(props: AlbumTileProps) {
-
-    const { rates } = useCurrency();
-    
-    const mintPrice = props.findRecordResponse.originalPriceSuggestion[Condition.Mint].value;
-    const goodPrice = props.findRecordResponse.originalPriceSuggestion[Condition.VeryGood].value;
-
-    const convertedMintPrice : number = (mintPrice * rates[props.selectedCurrency]);
-    const convertedGoodPrice : number = (goodPrice * rates[props.selectedCurrency]);
-
-    const currencySymbol = currencyOptions[props.selectedCurrency].symbol;
-
     return (
         <><div className="card lg:card-side bg-base-100 shadow-xl">
             <figure>
-                {/* Album art */}
                 {<Image src={props.findRecordResponse.image} alt={`Album art for ${props.findRecordResponse.title}`} width={600} height={600} style={{width: '100%', height: 'auto'}}/>}
             </figure>
 
             <div className="card-body">
-                {/* Album details */}
                 <h2 className="card-title">{props.findRecordResponse.title}</h2>
                 <p className="text-sm">by {props.findRecordResponse.artists}</p>
                 <div className="stats">
@@ -41,14 +27,10 @@ export default function AlbumTile(props: AlbumTileProps) {
                         <div className="stat-value text-indigo-800">{props.findRecordResponse.year}</div>
                     </div>
                 </div>
-                <p className='text-center'>
-                    <span className="text-lg font-bold">
-                        {currencySymbol}{Math.round(convertedGoodPrice)}-{currencySymbol}{Math.round(convertedMintPrice)}
-                    </span><br />
-                    <span className='text-xs text-gray-500'>
-                        For an original copy
-                    </span>
-                </p>
+                <ConditionSlider
+                    conditionValues={props.findRecordResponse.originalPriceSuggestion}
+                    selectedCurrency={props.selectedCurrency}
+                />
                 <StarRating average={props.findRecordResponse.rating.average} count={props.findRecordResponse.rating.count} />
 
                 <div className="flex flex-wrap justify-center gap-5">
@@ -61,6 +43,6 @@ export default function AlbumTile(props: AlbumTileProps) {
         <div className="mt-4">
             {props.findRecordResponse.summary && <p>{props.findRecordResponse.summary}</p>}
         </div></>
-    
+
     )
 }

--- a/app/search/components/ConditionSlider.test.tsx
+++ b/app/search/components/ConditionSlider.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConditionSlider from './ConditionSlider';
+import { Condition, ConditionValues } from '@/types/discogs';
+import { Currency } from '@/types/currency';
+
+jest.mock('@/app/currency-provider', () => ({
+  useCurrency: jest.fn(),
+}));
+
+import { useCurrency } from '@/app/currency-provider';
+
+const mockConditionValues: ConditionValues = {
+  [Condition.Mint]: { currency: 'USD', value: 50 },
+  [Condition.NearMint]: { currency: 'USD', value: 40 },
+  [Condition.VeryGoodPlus]: { currency: 'USD', value: 30 },
+  [Condition.VeryGood]: { currency: 'USD', value: 20 },
+  [Condition.GoodPlus]: { currency: 'USD', value: 15 },
+  [Condition.Good]: { currency: 'USD', value: 10 },
+  [Condition.Fair]: { currency: 'USD', value: 5 },
+  [Condition.Poor]: { currency: 'USD', value: 1 },
+};
+
+beforeEach(() => {
+  (useCurrency as jest.Mock).mockReturnValue({
+    rates: { USD: 1, GBP: 0.79 },
+    loading: false,
+  });
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('ConditionSlider', () => {
+  it('shows the VG+ price by default', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} />);
+    expect(screen.getByText('$30')).toBeInTheDocument();
+  });
+
+  it('renders "Poor" label at the left end of the slider', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} />);
+    expect(screen.getByText('Poor')).toBeInTheDocument();
+  });
+
+  it('renders "Mint" label at the right end of the slider', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} />);
+    expect(screen.getByText('Mint')).toBeInTheDocument();
+  });
+
+  it('updates price when slider moves to index 0 (Poor)', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} />);
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '0' } });
+    expect(screen.getByText('$1')).toBeInTheDocument();
+  });
+
+  it('updates price when slider moves to index 7 (Mint)', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} />);
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '7' } });
+    expect(screen.getByText('$50')).toBeInTheDocument();
+  });
+
+  it('applies currency conversion to the displayed price', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.GBP} />);
+    // VG+ value=30, GBP rate=0.79: Math.round(30 * 0.79) = 24
+    expect(screen.getByText('£24')).toBeInTheDocument();
+  });
+});

--- a/app/search/components/ConditionSlider.tsx
+++ b/app/search/components/ConditionSlider.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState } from 'react';
+import { Condition, ConditionValues } from '@/types/discogs';
+import { Currency, currencyOptions } from '@/types/currency';
+import { useCurrency } from '@/app/currency-provider';
+
+const CONDITIONS = [
+    { condition: Condition.Poor,         label: 'Poor' },
+    { condition: Condition.Fair,         label: 'Fair' },
+    { condition: Condition.Good,         label: 'Good' },
+    { condition: Condition.GoodPlus,     label: 'Good+' },
+    { condition: Condition.VeryGood,     label: 'Very Good' },
+    { condition: Condition.VeryGoodPlus, label: 'Very Good+' },
+    { condition: Condition.NearMint,     label: 'Near Mint' },
+    { condition: Condition.Mint,         label: 'Mint' },
+];
+
+const DEFAULT_INDEX = 5; // Very Good+
+
+interface ConditionSliderProps {
+    conditionValues: ConditionValues | null;
+    selectedCurrency: Currency;
+}
+
+export default function ConditionSlider({ conditionValues, selectedCurrency }: ConditionSliderProps) {
+    const [selectedIndex, setSelectedIndex] = useState(DEFAULT_INDEX);
+    const { rates } = useCurrency();
+
+    if (!conditionValues) return null;
+
+    const selected = CONDITIONS[selectedIndex];
+    const rawPrice = conditionValues[selected.condition].value;
+    const convertedPrice = Math.round(rawPrice * rates[selectedCurrency]);
+    const symbol = currencyOptions[selectedCurrency].symbol;
+
+    return (
+        <div className="flex flex-col items-center gap-2">
+            <p className="text-center">
+                <span className="text-lg font-bold">{symbol}{convertedPrice}</span>
+                <br />
+                <span className="text-xs text-gray-500">For an original copy</span>
+            </p>
+            <div className="flex w-full items-center gap-2">
+                <span className="text-xs text-gray-500">Poor</span>
+                <input
+                    type="range"
+                    min={0}
+                    max={7}
+                    step={1}
+                    value={selectedIndex}
+                    onChange={(e) => setSelectedIndex(Number(e.target.value))}
+                    className="range range-xs flex-1"
+                />
+                <span className="text-xs text-gray-500">Mint</span>
+            </div>
+        </div>
+    );
+}

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -108,6 +108,9 @@ test('submitting a search triggers loading state then renders AlbumTile', async 
 
   await expect(page.locator('button[type="submit"] .loading')).toBeVisible();
   await expect(page.locator('.card-title')).toHaveText('Abbey Road', { timeout: 10_000 });
+  await expect(page.locator('input[type="range"]')).toBeVisible();
+  // VG+ default: value=30, USD rate=1 → $30
+  await expect(page.getByText('$30')).toBeVisible();
 });
 
 test('currency selector is visible and changing it does not crash the page', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Replaces the static `$VG–$Mint` price range in `AlbumTile` with an interactive `ConditionSlider` component
- Slider runs from Poor (left) to Mint (right) with no Discogs jargon — only the two endpoint labels are shown
- Defaults to Very Good+ and converts to the user's selected currency in real time
- No data-model changes needed; all 8 conditions were already fetched and stored in `ReleaseData.originalPriceSuggestion`

## Key decisions

- Condition ordering (Poor → Mint) is an internal implementation detail of `ConditionSlider` — the `Condition` enum and `ConditionValues` type are unchanged
- Currency conversion moved from `AlbumTile` into `ConditionSlider`, keeping the tile itself stateless
- `conditionValues` accepts `null` and renders nothing, matching the existing nullable runtime behaviour of `originalPriceSuggestion`

## Test plan

- [x] 6 unit tests: default VG+ price, Poor/Mint endpoint labels, slider movement to both extremes, currency conversion
- [x] e2e: asserts slider is visible and `$30` (VG+ default) appears after a successful search
- [x] `npm test` — 78/78 passing
- [x] `npm run lint` — no warnings or errors
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)