### PR TITLE
refactor: remove 'For an original copy' label, add Condition label to slider

### DIFF
--- a/app/search/components/ConditionSlider.test.tsx
+++ b/app/search/components/ConditionSlider.test.tsx
@@ -52,6 +52,11 @@ describe('ConditionSlider', () => {
     expect(screen.getByText('Mint')).toBeInTheDocument();
   });
 
+  it('renders a "Condition" label above the slider', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} />);
+    expect(screen.getByText('Condition')).toBeInTheDocument();
+  });
+
   it('updates price when slider moves to index 0 (Poor)', () => {
     render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} />);
     const slider = screen.getByRole('slider');

--- a/app/search/components/ConditionSlider.tsx
+++ b/app/search/components/ConditionSlider.tsx
@@ -38,21 +38,22 @@ export default function ConditionSlider({ conditionValues, selectedCurrency }: C
         <div className="flex flex-col items-center gap-2">
             <p className="text-center">
                 <span className="text-lg font-bold">{symbol}{convertedPrice}</span>
-                <br />
-                <span className="text-xs text-gray-500">For an original copy</span>
             </p>
-            <div className="flex w-full items-center gap-2">
-                <span className="text-xs text-gray-500">Poor</span>
-                <input
-                    type="range"
-                    min={0}
-                    max={7}
-                    step={1}
-                    value={selectedIndex}
-                    onChange={(e) => setSelectedIndex(Number(e.target.value))}
-                    className="range range-xs flex-1"
-                />
-                <span className="text-xs text-gray-500">Mint</span>
+            <div className="flex w-full flex-col gap-1">
+                <span className="text-xs text-gray-500 text-center">Condition</span>
+                <div className="flex w-full items-center gap-2">
+                    <span className="text-xs text-gray-500">Poor</span>
+                    <input
+                        type="range"
+                        min={0}
+                        max={7}
+                        step={1}
+                        value={selectedIndex}
+                        onChange={(e) => setSelectedIndex(Number(e.target.value))}
+                        className="range range-xs flex-1"
+                    />
+                    <span className="text-xs text-gray-500">Mint</span>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

- Removes the "For an original copy" subtext below the price
- Adds a small centred "Condition" label above the Poor–Mint slider track

## Test plan

- [x] New test asserts "Condition" label is present in the DOM
- [x] `npm test` — 79/79 passing
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)