### PR TITLE
fix: use server-only AXIOM_TOKEN instead of NEXT_PUBLIC_

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,5 +3,5 @@ EXCHANGE_RATE_API_KEY=       # from exchangerate-api.com
 EXCHANGE_RATE_CACHE_DURATION=86400000
 ANTHROPIC_API_KEY=           # from console.anthropic.com
 NEXT_PUBLIC_SENTRY_DSN=      # from sentry.io project settings > Client Keys
-NEXT_PUBLIC_AXIOM_TOKEN=     # from axiom.co dataset settings
-NEXT_PUBLIC_AXIOM_DATASET=   # your axiom dataset name
+AXIOM_TOKEN=                 # from axiom.co settings > API tokens
+AXIOM_DATASET=               # your axiom dataset name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
           ANTHROPIC_API_KEY: dummy
           EXCHANGE_RATE_CACHE_DURATION: '86400000'
           NEXT_PUBLIC_SENTRY_DSN: ''
-          NEXT_PUBLIC_AXIOM_TOKEN: ''
-          NEXT_PUBLIC_AXIOM_DATASET: ''
+          AXIOM_TOKEN: ''
+          AXIOM_DATASET: ''
 
   e2e:
     runs-on: ubuntu-latest
@@ -52,8 +52,8 @@ jobs:
           ANTHROPIC_API_KEY: dummy
           EXCHANGE_RATE_CACHE_DURATION: '86400000'
           NEXT_PUBLIC_SENTRY_DSN: ''
-          NEXT_PUBLIC_AXIOM_TOKEN: ''
-          NEXT_PUBLIC_AXIOM_DATASET: ''
+          AXIOM_TOKEN: ''
+          AXIOM_DATASET: ''
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_AXIOM_TOKEN` and `NEXT_PUBLIC_AXIOM_DATASET` would have embedded the Axiom write token in the browser bundle, visible to anyone who inspects the page JS
- All `log` calls are in server actions and `libs/` — no client-side logging — so the `NEXT_PUBLIC_` prefix is unnecessary
- Corrected to `AXIOM_TOKEN` and `AXIOM_DATASET` in `.env.local.example` and the CI workflow

## Test plan
- [ ] Set `AXIOM_TOKEN` and `AXIOM_DATASET` (without `NEXT_PUBLIC_`) in Vercel env vars and redeploy
- [ ] Confirm logs appear in Axiom dataset after a search