### PR TITLE
fix: resolve sentry build warnings

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100vh", gap: "1rem", textAlign: "center", padding: "1rem" }}>
+          <p style={{ fontWeight: 600 }}>Something went wrong</p>
+          <p style={{ color: "#ef4444" }}>{error?.message}</p>
+          <button onClick={reset} style={{ padding: "0.5rem 1rem", cursor: "pointer" }}>
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,3 +4,5 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
 });
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
## Summary

- Renames `sentry.client.config.ts` → `instrumentation-client.ts` — Next.js's new convention, required for Turbopack compatibility. Also adds the `onRouterTransitionStart` hook Sentry needs to track client-side navigation events.
- Adds `app/global-error.tsx` — catches React rendering errors that bubble past the root layout (which `error.tsx` cannot catch). Calls `Sentry.captureException` the same way as `error.tsx`.

Build now produces zero Sentry warnings.

## Test plan
- [x] `npm test` — 79/79 passing
- [x] `npm run build` — no Sentry warnings