### PR TITLE
refactor: migrate axiom logging from next-axiom to @axiomhq/js

### DIFF
--- a/app/search/search-service.test.ts
+++ b/app/search/search-service.test.ts
@@ -4,7 +4,10 @@ import { Condition, ConditionValues, DiscogsMaster, DiscogsPaginatedSearchResult
 jest.mock('@/libs/discogs');
 jest.mock('@/libs/wiki');
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
-jest.mock('next-axiom', () => ({ log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } }));
+jest.mock('@/libs/axiom-logger', () => ({
+  log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  flushAxiom: jest.fn().mockResolvedValue(undefined),
+}));
 
 import { searchDiscogs, getDiscogsMasterRelease, getPriceSuggestion, getRating } from '@/libs/discogs';
 import { searchWiki, getWikiSummary } from '@/libs/wiki';

--- a/app/search/search-service.ts
+++ b/app/search/search-service.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { revalidatePath } from "next/cache";
-import { log } from "next-axiom";
+import { log, flushAxiom } from "@/libs/axiom-logger";
 import { searchDiscogs, getDiscogsMasterRelease, getPriceSuggestion, getRating } from "@/libs/discogs";
 import { getWikiSummary, searchWiki } from "@/libs/wiki";
 import { ConditionValues, DiscogsMaster } from "@/types/discogs";
@@ -24,6 +24,7 @@ export interface ReleaseData {
 }
 
 export async function findRelease(query: string): Promise<ReleaseData> {
+  try {
     log.info('findRelease started', { query });
 
     const type = "release";
@@ -97,4 +98,7 @@ export async function findRelease(query: string): Promise<ReleaseData> {
     revalidatePath("/");
     log.info('findRelease complete', { title: discogsMaster.title });
     return findRecordResponse;
+  } finally {
+    await flushAxiom();
+  }
 }

--- a/libs/axiom-logger.ts
+++ b/libs/axiom-logger.ts
@@ -1,0 +1,27 @@
+import { Axiom } from '@axiomhq/js';
+
+const token = process.env.AXIOM_TOKEN;
+const dataset = process.env.AXIOM_DATASET;
+const isConfigured = Boolean(token && dataset);
+
+const axiomClient = isConfigured ? new Axiom({ token: token! }) : null;
+
+type Fields = Record<string, unknown>;
+
+function makeLog(level: 'info' | 'warn' | 'error') {
+  return (message: string, fields: Fields = {}): void => {
+    if (!axiomClient) return;
+    axiomClient.ingest(dataset!, [{ level, message, ...fields }]);
+  };
+}
+
+export const log = {
+  info:  makeLog('info'),
+  warn:  makeLog('warn'),
+  error: makeLog('error'),
+};
+
+export async function flushAxiom(): Promise<void> {
+  if (!axiomClient) return;
+  await axiomClient.flush();
+}

--- a/libs/discogs.test.ts
+++ b/libs/discogs.test.ts
@@ -1,6 +1,6 @@
-jest.mock('next-axiom', () => ({ log: { error: jest.fn(), info: jest.fn() } }));
+jest.mock('@/libs/axiom-logger', () => ({ log: { error: jest.fn(), info: jest.fn() }, flushAxiom: jest.fn() }));
 
-import { log } from 'next-axiom';
+import { log } from '@/libs/axiom-logger';
 import { getDiscogsMasterRelease, searchDiscogs, getPriceSuggestion, getRating } from './discogs';
 import type { DiscogsItem } from '@/types/discogs';
 

--- a/libs/discogs.ts
+++ b/libs/discogs.ts
@@ -1,4 +1,4 @@
-import { log } from "next-axiom";
+import { log } from "@/libs/axiom-logger";
 import { Condition, ConditionValues, DiscogsMaster, DiscogsPaginatedSearchResult, DiscogsRatingResponse } from "@/types/discogs";
 
 export async function getDiscogsMasterRelease(masterId: number): Promise<DiscogsMaster> {

--- a/libs/wiki.test.ts
+++ b/libs/wiki.test.ts
@@ -6,10 +6,10 @@ jest.mock('wikipedia', () => ({
   },
 }));
 
-jest.mock('next-axiom', () => ({ log: { error: jest.fn(), info: jest.fn() } }));
+jest.mock('@/libs/axiom-logger', () => ({ log: { error: jest.fn(), info: jest.fn() }, flushAxiom: jest.fn() }));
 
 import wiki from 'wikipedia';
-import { log } from 'next-axiom';
+import { log } from '@/libs/axiom-logger';
 import { getWikiSummary, searchWiki } from './wiki';
 
 const mockWiki = wiki as jest.Mocked<typeof wiki>;

--- a/libs/wiki.ts
+++ b/libs/wiki.ts
@@ -1,5 +1,5 @@
 import wiki, { wikiSearchResult, wikiSummary } from "wikipedia";
-import { log } from "next-axiom";
+import { log } from "@/libs/axiom-logger";
 
 export async function getWikiSummary(title: string): Promise<wikiSummary> {
     try {

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const { withSentryConfig } = require('@sentry/nextjs');
-const { withAxiom } = require('next-axiom');
 
 const nextConfig = {
   reactStrictMode: true,
@@ -12,7 +11,7 @@ const nextConfig = {
   },
 };
 
-module.exports = withSentryConfig(withAxiom(nextConfig), {
+module.exports = withSentryConfig(nextConfig, {
   silent: true,
   hideSourceMaps: true,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
+        "@axiomhq/js": "^1.6.1",
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.2.0",
         "@sentry/nextjs": "^10.51.0",
@@ -16,7 +17,6 @@
         "eslint": "8.47.0",
         "eslint-config-next": "13.4.19",
         "next": "^14.1.4",
-        "next-axiom": "^1.10.0",
         "nextjs-toploader": "^1.6.11",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -104,6 +104,18 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@axiomhq/js": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@axiomhq/js/-/js-1.6.1.tgz",
+      "integrity": "sha512-iNWOnGvP+R2lIWYk9jkfvRI/rfhOR9hlWJOBJhMKwZ9mfpE0KdnFnG2XPLoMcrbyrOBKj6Jw0hpIH5GhPucLog==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-retry": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3887,12 +3899,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT"
-    },
     "node_modules/@types/mysql": {
       "version": "2.15.27",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
@@ -4399,39 +4405,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@vercel/functions": {
-      "version": "2.2.13",
-      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-2.2.13.tgz",
-      "integrity": "sha512-14ArBSIIcOBx9nrEgaJb4Bw+en1gl6eSoJWh8qjifLl5G3E4dRXCFOT8HP+w66vb9Wqyd1lAQBrmRhRwOj9X9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@vercel/oidc": "2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-provider-web-identity": "*"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-provider-web-identity": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vercel/oidc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-2.0.2.tgz",
-      "integrity": "sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/ms": "2.1.0",
-        "ms": "2.1.3"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -6720,6 +6693,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -9159,24 +9138,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-axiom": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/next-axiom/-/next-axiom-1.10.0.tgz",
-      "integrity": "sha512-PpwmfOqoa2xWKcGmYb3d5t3R4+/J8C2D00IhJsI3Qk0xxv9tNvGzS/hKKOPNOuUwqM4b/etqu6iGW7tkKvltgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vercel/functions": "^2.2.13",
-        "use-deep-compare": "^1.3.0",
-        "whatwg-fetch": "^3.6.20"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "next": ">=14.0",
-        "react": ">=18.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -11665,18 +11626,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-deep-compare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-deep-compare/-/use-deep-compare-1.3.0.tgz",
-      "integrity": "sha512-94iG+dEdEP/Sl3WWde+w9StIunlV8Dgj+vkt5wTwMoFQLaijiEZSXXy8KtcStpmEDtIptRJiNeD4ACTtVvnIKA==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "2.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -11851,12 +11800,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
+    "@axiomhq/js": "^1.6.1",
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.2.0",
     "@sentry/nextjs": "^10.51.0",
@@ -19,7 +20,6 @@
     "eslint": "8.47.0",
     "eslint-config-next": "13.4.19",
     "next": "^14.1.4",
-    "next-axiom": "^1.10.0",
     "nextjs-toploader": "^1.6.11",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
## Summary

- Replaces `next-axiom` v1.10.0 with `@axiomhq/js`, the current Axiom library
- Creates `libs/axiom-logger.ts` as a server-side logger singleton — silent no-op when `AXIOM_TOKEN` is absent (CI, local dev)
- Adds `flushAxiom()` in a `try/finally` block in `findRelease` to guarantee logs are flushed before the serverless function exits
- Removes the `withAxiom` wrapper from `next.config.js` (not needed by the new library)
- `AXIOM_TOKEN` and `AXIOM_DATASET` remain server-only env vars — no `NEXT_PUBLIC_` prefix

## Key decisions

**Direct `@axiomhq/js` instead of `@axiomhq/logging`**: The higher-level `Logger`/`AxiomJSTransport` abstraction adds no value for a purely server-side codebase. Using `Axiom.ingest()` directly keeps the logger thin and the no-op guard trivially clear.

**Explicit flush via try/finally**: `next-axiom`'s `withAxiomNextConfig` handled flushing implicitly. The new library buffers in memory and requires an explicit `axiomClient.flush()` — placing this in `finally` ensures it runs on both success and thrown error paths.

**No WebVitals in this PR**: Adding WebVitals tracking requires `@axiomhq/react` and a proxy route handler; that's new functionality, not part of migrating existing logging. Deferred to a follow-up.

## Test plan

- [x] `npm test` — 79 tests pass
- [x] `npm run lint` — no warnings or errors
- [x] `npm run build` — clean build, no TypeScript errors
- [ ] Deploy to Vercel preview and confirm log events appear in Axiom dataset after a search

🤖 Generated with [Claude Code](https://claude.com/claude-code)