### PR TITLE
fix: surface axiom client errors in vercel logs

### DIFF
--- a/libs/axiom-logger.ts
+++ b/libs/axiom-logger.ts
@@ -4,7 +4,9 @@ const token = process.env.AXIOM_TOKEN;
 const dataset = process.env.AXIOM_DATASET;
 const isConfigured = Boolean(token && dataset);
 
-const axiomClient = isConfigured ? new Axiom({ token: token! }) : null;
+const axiomClient = isConfigured
+  ? new Axiom({ token: token!, onError: (err) => console.error('[axiom]', err) })
+  : null;
 
 type Fields = Record<string, unknown>;
 
@@ -23,5 +25,9 @@ export const log = {
 
 export async function flushAxiom(): Promise<void> {
   if (!axiomClient) return;
-  await axiomClient.flush();
+  try {
+    await axiomClient.flush();
+  } catch (err) {
+    console.error('[axiom] flush failed', err);
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `onError` to the `Axiom` constructor so batch flush failures (auth errors, network errors) are printed via `console.error` and appear in Vercel function logs
- Wraps `flushAxiom()` in a try/catch for the same reason

## Why

After deploying the `@axiomhq/js` migration, no events were appearing in Axiom. The batch queue's `onError` was silently discarding any failures. This change makes those errors visible in Vercel logs so we can diagnose the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)