### PR TITLE
fix: route axiom ingest to eu api endpoint

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,3 +5,4 @@ ANTHROPIC_API_KEY=           # from console.anthropic.com
 NEXT_PUBLIC_SENTRY_DSN=      # from sentry.io project settings > Client Keys
 AXIOM_TOKEN=                 # from axiom.co settings > API tokens
 AXIOM_DATASET=               # your axiom dataset name
+AXIOM_URL=                   # omit for US; set to https://api.eu.axiom.co for EU datasets

--- a/libs/axiom-logger.ts
+++ b/libs/axiom-logger.ts
@@ -5,7 +5,11 @@ const dataset = process.env.AXIOM_DATASET;
 const isConfigured = Boolean(token && dataset);
 
 const axiomClient = isConfigured
-  ? new Axiom({ token: token!, onError: (err) => console.error('[axiom]', err) })
+  ? new Axiom({
+      token: token!,
+      url: process.env.AXIOM_URL,
+      onError: (err) => console.error('[axiom]', err),
+    })
   : null;
 
 type Fields = Record<string, unknown>;


### PR DESCRIPTION
## Summary

- Adds `AXIOM_URL` env var support to the Axiom client constructor
- Documents the var in `.env.local.example`
- `AXIOM_URL=https://api.eu.axiom.co` has been set in Vercel (production + preview)

## Root cause

The `@axiomhq/js` client defaults to the US East API endpoint (`api.axiom.co`). The dataset lives in `eu-central-1.aws`, so every ingest was rejected with:

```
ingest is only allowed into datasets in the primary region:
dataset region: cloud.eu-central-1.aws, deployment region: cloud.us-east-1.aws
```

## Fix

Pass `url: process.env.AXIOM_URL` to the `Axiom` constructor. When unset the client falls back to its default (US), so existing US datasets and local dev are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)