### PR TITLE
fix: use axiom edge endpoint for eu ingest

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,4 +5,4 @@ ANTHROPIC_API_KEY=           # from console.anthropic.com
 NEXT_PUBLIC_SENTRY_DSN=      # from sentry.io project settings > Client Keys
 AXIOM_TOKEN=                 # from axiom.co settings > API tokens
 AXIOM_DATASET=               # your axiom dataset name
-AXIOM_URL=                   # omit for US; set to https://api.eu.axiom.co for EU datasets
+AXIOM_URL=                   # omit for US; set to https://eu-central-1.aws.edge.axiom.co for EU datasets

--- a/libs/axiom-logger.ts
+++ b/libs/axiom-logger.ts
@@ -7,7 +7,7 @@ const isConfigured = Boolean(token && dataset);
 const axiomClient = isConfigured
   ? new Axiom({
       token: token!,
-      url: process.env.AXIOM_URL,
+      edgeUrl: process.env.AXIOM_URL,
       onError: (err) => console.error('[axiom]', err),
     })
   : null;


### PR DESCRIPTION
## Summary

Switches the `@axiomhq/js` client from `url` to `edgeUrl` option.

## Root cause

Setting `url: 'https://api.eu.axiom.co'` routes ingest to the legacy API endpoint (`/v1/datasets/{dataset}/ingest`) which was returning 403. The edge endpoint (`eu-central-1.aws.edge.axiom.co`, path `/v1/ingest/{dataset}`) returned a different error (401 invalid token with a rotated token) suggesting it's the correct ingest path for EU datasets.

`AXIOM_URL` in Vercel has been updated to `https://eu-central-1.aws.edge.axiom.co`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)