### PR TITLE
docs: update README with observability stack, add sync instruction to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,10 @@ In production the logger sends to an EU dataset; the Axiom client must be pointe
 
 TailwindCSS with DaisyUI component classes. Theme is set via `data-theme` on `<html>` — driven by `config.colors.theme` from `config.ts`. Global styles are in `app/globals.css`.
 
+## Documentation
+
+When making changes that affect the stack, architecture, observability setup, or local dev workflow, update both `CLAUDE.md` (for future Claude sessions) and `README.md` (the owner's reference). The README lives at the project root and is the human-facing equivalent of this file — keep the Stack, Observability, and Key design notes sections in sync.
+
 ## Vision
 
 The long-term goal is frictionless vinyl pricing: point a camera at an album cover and get an estimated price. The intended approach is to send a captured frame to a vision LLM (e.g. Claude Haiku) server-side, extract artist and title, then pass that as a free-text query to the existing Discogs pipeline. Text search is an interim input method on the way to that goal.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Built by William (william@thewhisk.dev)
 - **Anthropic API** — vision model for album cover identification
 - **Wikipedia npm package** — album summaries
 - **ExchangeRate-API** — currency conversion (cached 24h)
+- **Sentry** — error tracking
+- **Axiom** — structured server-side logging
 - **Jest** (via `next/jest`) + **Playwright** — test suite
 
 ## Local development
@@ -44,6 +46,8 @@ EXCHANGE_RATE_API_KEY=       # from exchangerate-api.com
 EXCHANGE_RATE_CACHE_DURATION=86400000
 ANTHROPIC_API_KEY=           # from console.anthropic.com
 ```
+
+Axiom and Sentry credentials are intentionally omitted from `.env.local` — logs and error reports are production-only. The Axiom logger is a silent no-op when `AXIOM_TOKEN` is absent.
 
 ## Project structure
 
@@ -66,6 +70,11 @@ types/
   discogs.ts                # Discogs API types
   currency.ts               # Currency types
 ```
+
+## Observability
+
+- **Sentry** — catches unhandled exceptions in production. Configured via `NEXT_PUBLIC_SENTRY_DSN`.
+- **Axiom** — structured logging (`log.info/warn/error`) from server-side code. Singleton in `libs/axiom-logger.ts`. Dataset is EU-hosted; requires `AXIOM_URL=https://eu-central-1.aws.edge.axiom.co` alongside `AXIOM_TOKEN` and `AXIOM_DATASET`. All three are set in Vercel — not needed locally.
 
 ## Key design notes
 


### PR DESCRIPTION
- Adds Sentry and Axiom to the Stack section of README
- Adds an Observability section to README documenting both tools, EU edge endpoint, and local dev behaviour
- Notes in README that Axiom/Sentry credentials are production-only
- Adds a Documentation section to CLAUDE.md instructing future sessions to keep README and CLAUDE.md in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)