### PR TITLE
fix: replace wikipedia axios client with native fetch

### DIFF
--- a/libs/wiki.test.ts
+++ b/libs/wiki.test.ts
@@ -1,77 +1,78 @@
-jest.mock('wikipedia', () => ({
-  __esModule: true,
-  default: {
-    summary: jest.fn(),
-    search: jest.fn(),
-    setUserAgent: jest.fn(),
-  },
-}));
-
 jest.mock('@/libs/axiom-logger', () => ({ log: { error: jest.fn(), info: jest.fn() }, flushAxiom: jest.fn() }));
 
-import wiki from 'wikipedia';
 import { log } from '@/libs/axiom-logger';
 import { getWikiSummary, searchWiki } from './wiki';
 
-const mockWiki = wiki as jest.Mocked<typeof wiki>;
 const mockLog = log as any;
 
 beforeEach(() => {
   jest.clearAllMocks();
-});
-
-describe('getWikiSummary', () => {
-  it('returns the summary from wikipedia', async () => {
-    const mockSummary = { extract: 'A great album about life on the road.' };
-    mockWiki.summary.mockResolvedValueOnce(mockSummary as any);
-
-    const result = await getWikiSummary('Abbey Road');
-
-    expect(result).toEqual(mockSummary);
-    expect(mockWiki.summary).toHaveBeenCalledWith('Abbey Road');
-  });
-
-  it('rethrows as "Error searching Wikipedia" when wiki.summary throws', async () => {
-    mockWiki.summary.mockRejectedValueOnce(new Error('page not found'));
-
-    await expect(getWikiSummary('Nonexistent Album')).rejects.toThrow('Error searching Wikipedia');
-  });
-
-  it('logs the error with log.error when wiki.summary throws', async () => {
-    const err = new Error('page not found');
-    mockWiki.summary.mockRejectedValueOnce(err);
-
-    await expect(getWikiSummary('Nonexistent Album')).rejects.toThrow();
-    expect(mockLog.error).toHaveBeenCalledWith('wiki summary lookup failed', expect.objectContaining({
-      error: { name: err.name, message: err.message, cause: undefined },
-    }));
-  });
+  global.fetch = jest.fn();
 });
 
 describe('searchWiki', () => {
-  it('returns search results from wikipedia', async () => {
-    const mockResults = { results: [{ title: 'Abbey Road (album)', pageid: 1 }] };
-    mockWiki.search.mockResolvedValueOnce(mockResults as any);
+  it('returns search results from the Wikipedia API', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ query: { search: [{ title: 'Abbey Road (album)' }] } }),
+    });
 
     const result = await searchWiki('Abbey Road Beatles');
 
-    expect(result).toEqual(mockResults);
-    expect(mockWiki.search).toHaveBeenCalledWith('Abbey Road Beatles');
+    expect(result).toEqual({ results: [{ title: 'Abbey Road (album)' }] });
   });
 
-  it('rethrows as "Error searching Wikipedia" when wiki.search throws', async () => {
-    mockWiki.search.mockRejectedValueOnce(new Error('network failure'));
+  it('returns empty results when query field is absent', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ query: {} }),
+    });
+
+    const result = await searchWiki('no results query');
+
+    expect(result).toEqual({ results: [] });
+  });
+
+  it('rethrows as "Error searching Wikipedia" when fetch fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 403 });
 
     await expect(searchWiki('Abbey Road Beatles')).rejects.toThrow('Error searching Wikipedia');
   });
 
-  it('logs the error with log.error when wiki.search throws', async () => {
-    const err = new Error('network failure');
-    mockWiki.search.mockRejectedValueOnce(err);
+  it('logs the error with log.error when fetch fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 403 });
 
     await expect(searchWiki('Abbey Road Beatles')).rejects.toThrow();
     expect(mockLog.error).toHaveBeenCalledWith('wiki search failed', expect.objectContaining({
-      error: { name: err.name, message: err.message, cause: undefined },
+      error: expect.objectContaining({ message: 'HTTP 403' }),
+    }));
+  });
+});
+
+describe('getWikiSummary', () => {
+  it('returns the extract from the Wikipedia REST API', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ extract: 'A great album about life on the road.' }),
+    });
+
+    const result = await getWikiSummary('Abbey Road (album)');
+
+    expect(result).toEqual({ extract: 'A great album about life on the road.' });
+  });
+
+  it('rethrows as "Error searching Wikipedia" when fetch fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 404 });
+
+    await expect(getWikiSummary('Nonexistent Album')).rejects.toThrow('Error searching Wikipedia');
+  });
+
+  it('logs the error with log.error when fetch fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 404 });
+
+    await expect(getWikiSummary('Nonexistent Album')).rejects.toThrow();
+    expect(mockLog.error).toHaveBeenCalledWith('wiki summary lookup failed', expect.objectContaining({
+      error: expect.objectContaining({ message: 'HTTP 404' }),
     }));
   });
 });

--- a/libs/wiki.ts
+++ b/libs/wiki.ts
@@ -1,9 +1,8 @@
-import wiki, { wikiSearchResult, wikiSummary } from "wikipedia";
 import { log } from "@/libs/axiom-logger";
 
-// Wikipedia API etiquette requires an identifying User-Agent; the library
-// default is a generic string that gets 403'd from cloud IPs.
-wiki.setUserAgent('CrateMole/1.0 (https://github.com/theWhisk/unwave-record-companion)');
+const USER_AGENT = 'CrateMole/1.0 (https://github.com/theWhisk/unwave-record-companion)';
+const WIKI_API = 'https://en.wikipedia.org/w/api.php';
+const WIKI_REST = 'https://en.wikipedia.org/api/rest_v1';
 
 function serializeError(error: unknown): Record<string, unknown> {
     if (error instanceof Error) {
@@ -16,22 +15,47 @@ function serializeError(error: unknown): Record<string, unknown> {
     return { raw: String(error) };
 }
 
-export async function getWikiSummary(title: string): Promise<wikiSummary> {
+export interface WikiSearchResult {
+    results: Array<{ title: string }>;
+}
+
+export interface WikiSummary {
+    extract: string;
+}
+
+export async function searchWiki(query: string): Promise<WikiSearchResult> {
     try {
-        const summary = await wiki.summary(title);
-        return summary;
+        const params = new URLSearchParams({
+            action: 'query',
+            list: 'search',
+            srsearch: query,
+            srlimit: '5',
+            srprop: '',
+            format: 'json',
+            origin: '*',
+        });
+        const response = await fetch(`${WIKI_API}?${params}`, {
+            headers: { 'User-Agent': USER_AGENT },
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
+        return { results: data.query?.search ?? [] };
     } catch (error) {
-        log.error('wiki summary lookup failed', { error: serializeError(error) });
-        throw new Error("Error searching Wikipedia");
+        log.error('wiki search failed', { error: serializeError(error) });
+        throw new Error('Error searching Wikipedia');
     }
 }
 
-export async function searchWiki(query: string): Promise<wikiSearchResult> {
+export async function getWikiSummary(title: string): Promise<WikiSummary> {
     try {
-        const results = await wiki.search(query);
-        return results;
+        const response = await fetch(`${WIKI_REST}/page/summary/${encodeURIComponent(title)}`, {
+            headers: { 'User-Agent': USER_AGENT },
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
+        return { extract: data.extract ?? '' };
     } catch (error) {
-        log.error('wiki search failed', { error: serializeError(error) });
-        throw new Error("Error searching Wikipedia");
+        log.error('wiki summary lookup failed', { error: serializeError(error) });
+        throw new Error('Error searching Wikipedia');
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the `axios`-backed HTTP client used by the `wikipedia` npm package with native `fetch`
- The `wikipedia` package sets `Api-User-Agent` (a MediaWiki header) but leaves the standard HTTP `User-Agent` as axios's default, which Wikipedia's CDN blocks from Vercel datacenter IPs with a 403
- Switching to native fetch allows `User-Agent` to be set directly, and removes the axios dependency for these calls entirely

## Test plan

- [ ] Unit tests in `libs/wiki.test.ts` cover the updated fetch-based implementation
- [ ] Verify 403 errors from Wikipedia CDN are resolved in production/preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)