### PR TITLE
refactor: replace set-state-in-effect with key prop reset in Header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Suspense, useState } from "react";
+import { useState } from "react";
+import { usePathname } from "next/navigation";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import AlbumTile from "@/app/search/components/AlbumTile";
@@ -11,6 +12,7 @@ import { CurrencySelector } from "@/components/CurrencySelector";
 import { Currency } from "@/types/currency";
 
 export default function Home() {
+  const pathname = usePathname();
   const [findRecordResponse, setRecordResponse] = useState<ReleaseData>();
   const [searchAttempted, setSearchAttempted] = useState<boolean>(false);
   const [selectedCurrency, setSelectedCurrency] = useState<Currency>(Currency.USD);
@@ -26,9 +28,7 @@ export default function Home() {
 
   return (
     <>
-      <Suspense>
-        <Header />
-      </Suspense>
+      <Header key={pathname} />
       <main className="min-h-screen p-8 pb-24">
         <section className="max-w-xl mx-auto space-y-8 flex justify-end">
           <CurrencySelector onCurrencyChange={handleCurrencyChange} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useSearchParams } from "next/navigation";
+import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import logo from "@/app/Unwavev3Icon.png";
@@ -16,13 +15,7 @@ const links: {
 // A header with a logo on the left, links in the center (like Pricing, etc...), and a CTA (like Get Started or Login) on the right.
 // The header is responsive, and on mobile, the links are hidden behind a burger button.
 const Header = () => {
-  const searchParams = useSearchParams();
   const [isOpen, setIsOpen] = useState<boolean>(false);
-
-  // setIsOpen(false) when the route changes (i.e: when the user clicks on a link on mobile)
-  useEffect(() => {
-    setIsOpen(false);
-  }, [searchParams]);
 
   return (
     <header className="bg-base-200">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,14 +28,6 @@ const config = [
       'no-unused-vars': ['warn', unusedVarsConfig],
     },
   },
-  {
-    // react-hooks/set-state-in-effect is a new rule in eslint-plugin-react-hooks v5
-    // (shipped with Next.js 16). Turned off; the existing useEffect reset patterns
-    // in this codebase are intentional and require separate refactoring work.
-    rules: {
-      'react-hooks/set-state-in-effect': 'off',
-    },
-  },
 ];
 
 export default config;


### PR DESCRIPTION
## What and why

`Header.tsx` used a `useEffect` that called `setIsOpen(false)` whenever `useSearchParams()` changed. This pattern violates the `react-hooks/set-state-in-effect` rule (introduced in eslint-plugin-react-hooks v5, shipped with Next.js 16 — PR #49), which warns against calling `setState` synchronously inside an effect because it causes a double render in React 19.

The rule was temporarily silenced in `eslint.config.mjs` to unblock the upgrade. This PR removes the underlying violation and re-enables the rule.

## Approach

Replace the effect with the idiomatic React 19 **`key` prop pattern**:

- `usePathname()` is read in `app/page.tsx`
- `pathname` is passed as `key` to `<Header key={pathname} />`
- When the pathname changes (navigation), React unmounts and remounts `Header`, resetting `isOpen` to `false` automatically — no effect needed

The `<Suspense>` wrapper that previously surrounded `<Header>` is also removed; it was only required because `useSearchParams()` needs it, and that hook is gone.

## Key decisions

- Chose `key` over keeping `useEffect` with `usePathname` as dependency — the latter still calls `setState` in an effect and would still fail the lint rule.
- `usePathname` does not require `Suspense` in a client component, so the wrapper is safe to drop.

## Verification

- `npm run lint` — exits 0, `react-hooks/set-state-in-effect` is active (not suppressed)
- `npm test` — 80/80 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)