### PR TITLE
docs: update stack version references after next@16 upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 npm run dev       # Start dev server (localhost:3000)
 npm run build     # Production build
-npm run lint      # ESLint via next lint
+npm run lint      # ESLint 9 (eslint.config.mjs)
 npm test          # Run Jest test suite
 npm run test:e2e  # Run Playwright e2e suite (starts dev server automatically)
 ```
@@ -22,7 +22,7 @@ EXCHANGE_RATE_CACHE_DURATION=86400000
 
 ## Architecture
 
-**Crate Mole** is a Next.js 14 App Router app. Users search for a vinyl record; the app returns pricing by condition, ratings, genre tags, album art, and a Wikipedia summary.
+**Crate Mole** is a Next.js 16 App Router app. Users search for a vinyl record; the app returns pricing by condition, ratings, genre tags, album art, and a Wikipedia summary.
 
 ### Request flow
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Built by William (william@thewhisk.dev)
 
 ## Stack
 
-- **Next.js 14** (App Router, TypeScript, server actions)
+- **Next.js 16** (App Router, TypeScript, server actions)
 - **TailwindCSS** + **DaisyUI** for styling
 - **Discogs API** — record database, marketplace pricing, ratings
 - **Anthropic API** — vision model for album cover identification


### PR DESCRIPTION
Follows on from #49. Updates the two places where the Next.js version was hardcoded, and corrects the lint command description now that `next lint` is no longer used.

- `CLAUDE.md`: Next.js 14 → 16; lint comment `ESLint via next lint` → `ESLint 9 (eslint.config.mjs)`
- `README.md`: Next.js 14 → 16 in the Stack section