### PR TITLE
docs: update stack references after tailwind@4 / daisyui@5 upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ In production the logger sends to an EU dataset; the Axiom client must be pointe
 
 ### Styling
 
-TailwindCSS with DaisyUI component classes. Theme is set via `data-theme` on `<html>` — driven by `config.colors.theme` from `config.ts`. Global styles are in `app/globals.css`.
+TailwindCSS v4 with DaisyUI v5 component classes. Both use CSS-first configuration: there is no `tailwind.config.js`. All theme tokens, custom colors, keyframes, animations, and the DaisyUI plugin (`@plugin "daisyui"`) and theme list are declared in `app/globals.css` via `@import "tailwindcss"` and `@theme {}`. The PostCSS pipeline uses `@tailwindcss/postcss` (no `autoprefixer`). The runtime DaisyUI theme is set via `data-theme` on `<html>` — driven by `config.colors.theme` from `config.ts`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Built by William (william@thewhisk.dev)
 ## Stack
 
 - **Next.js 16** (App Router, TypeScript, server actions)
-- **TailwindCSS** + **DaisyUI** for styling
+- **TailwindCSS v4** + **DaisyUI v5** for styling (CSS-first config in `app/globals.css`)
 - **Discogs API** — record database, marketplace pricing, ratings
 - **Anthropic API** — vision model for album cover identification
 - **Wikipedia npm package** — album summaries


### PR DESCRIPTION
## Summary

- Updates `CLAUDE.md` Styling section and `README.md` Stack list to reflect the v4/v5 upgrade landed in #52.
- Notes the move to CSS-first config (no `tailwind.config.js`, theme tokens in `globals.css`, `@tailwindcss/postcss`, no `autoprefixer`).

## Test plan

- [x] No code changes — docs only