### PR TITLE
feat: redesign AlbumTile with minimal lofi-consistent layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -97,6 +97,76 @@
   }
 }
 
+:root {
+  --clay:      oklch(0.58 0.12 45);
+  --clay-soft: oklch(0.94 0.04 60);
+  --clay-ink:  oklch(0.36 0.10 40);
+  --muted:     #6b6760;
+  --soft:      #f0ede5;
+  --hairline:  #e4e2dd;
+  --dark:      #3f3f3f;
+  --ink:       #1a1a1a;
+  --star:      #ee7a1d;
+}
+
+/* Custom range slider — used by ConditionSlider */
+.cm-range {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  background: transparent;
+  height: 28px;
+  margin: 0;
+  cursor: pointer;
+}
+.cm-range:focus { outline: none; }
+.cm-range::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--clay) 0%,
+    var(--clay) var(--cm-fill, 50%),
+    var(--hairline) var(--cm-fill, 50%),
+    var(--hairline) 100%
+  );
+}
+.cm-range::-moz-range-track {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--hairline);
+}
+.cm-range::-moz-range-progress {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--clay);
+}
+.cm-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--clay);
+  margin-top: -8px;
+  box-shadow: 0 2px 6px -2px rgba(0,0,0,0.25);
+  cursor: grab;
+}
+.cm-range:active::-webkit-slider-thumb {
+  cursor: grabbing;
+  transform: scale(1.06);
+}
+.cm-range::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--clay);
+  box-shadow: 0 2px 6px -2px rgba(0,0,0,0.25);
+  cursor: grab;
+}
+
 html,
 body {
   scroll-behavior: smooth !important;

--- a/app/search/components/AlbumTile.tsx
+++ b/app/search/components/AlbumTile.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react';
 import Image from 'next/image';
 import { ReleaseData } from '../search-service';
 import StarRating from '@/components/StarRating';

--- a/app/search/components/AlbumTile.tsx
+++ b/app/search/components/AlbumTile.tsx
@@ -5,44 +5,104 @@ import { ReleaseData } from '../search-service';
 import StarRating from '@/components/StarRating';
 import { Currency } from '@/types/currency';
 import ConditionSlider from './ConditionSlider';
+import { staatliches } from '@/styles/fonts';
 
 interface AlbumTileProps {
-    findRecordResponse: ReleaseData
-    selectedCurrency: Currency
-  }
+    findRecordResponse: ReleaseData;
+    selectedCurrency: Currency;
+}
 
-export default function AlbumTile(props: AlbumTileProps) {
+const MONO = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace';
+
+function Pill({ children, tone = 'neutral' }: { children: React.ReactNode; tone?: 'neutral' | 'clay' }) {
+    const base: React.CSSProperties = {
+        display: 'inline-flex', alignItems: 'center',
+        height: 24, padding: '0 10px',
+        borderRadius: 999, fontSize: 12, letterSpacing: 0.1,
+    };
+    const toneStyle: React.CSSProperties = tone === 'clay'
+        ? { background: 'var(--clay-soft)', color: 'var(--clay-ink)' }
+        : { background: 'transparent', color: 'var(--ink)', boxShadow: 'inset 0 0 0 1px var(--hairline)' };
+    return <span style={{ ...base, ...toneStyle }}>{children}</span>;
+}
+
+export default function AlbumTile({ findRecordResponse: data, selectedCurrency }: AlbumTileProps) {
     return (
-        <><div className="card lg:card-side bg-base-100 shadow-xl">
-            <figure>
-                {<Image src={props.findRecordResponse.image} alt={`Album art for ${props.findRecordResponse.title}`} width={600} height={600} style={{width: '100%', height: 'auto'}}/>}
-            </figure>
-
-            <div className="card-body">
-                <h2 className="card-title">{props.findRecordResponse.title}</h2>
-                <p className="text-sm">by {props.findRecordResponse.artists}</p>
-                <div className="stats">
-                    <div className="stat">
-                        <div className="stat-title">First released in</div>
-                        <div className="stat-value text-indigo-800">{props.findRecordResponse.year}</div>
-                    </div>
+        <div style={{
+            borderRadius: 4, overflow: 'hidden',
+            background: '#fff',
+            boxShadow: '0 1px 0 var(--hairline), 0 12px 28px -16px rgba(60,50,40,0.25)',
+        }}>
+            <div style={{ display: 'flex', padding: 22, gap: 22, alignItems: 'flex-start' }}>
+                {/* Cover art */}
+                <div style={{ position: 'relative', width: 200, height: 200, flexShrink: 0, overflow: 'hidden' }}>
+                    <Image
+                        src={data.image}
+                        alt={`Album art for ${data.title}`}
+                        fill
+                        style={{ objectFit: 'cover' }}
+                    />
                 </div>
-                <ConditionSlider
-                    conditionValues={props.findRecordResponse.originalPriceSuggestion}
-                    selectedCurrency={props.selectedCurrency}
-                />
-                <StarRating average={props.findRecordResponse.rating.average} count={props.findRecordResponse.rating.count} />
 
-                <div className="flex flex-wrap justify-center gap-5">
-                    {props.findRecordResponse.genres.map((genre, index) => (
-                        <span className="badge badge-success gap-2" key={index}>{genre}</span>
-                    ))}
+                {/* Right column */}
+                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 14 }}>
+                    {/* Year · tracks meta */}
+                    <div style={{
+                        fontFamily: MONO, fontSize: 10,
+                        letterSpacing: '0.18em', textTransform: 'uppercase',
+                        color: 'var(--muted)',
+                    }}>
+                        {data.year} · {data.noOfTracks} tracks
+                    </div>
+
+                    {/* Title + artist */}
+                    <div>
+                        <h2 style={{
+                            margin: 0,
+                            fontFamily: staatliches.style.fontFamily,
+                            fontWeight: 400, fontSize: 32, lineHeight: 0.95, letterSpacing: 0.4,
+                        }}>
+                            {data.title}
+                        </h2>
+                        <div style={{ marginTop: 4, fontSize: 14, color: 'var(--dark)' }}>
+                            {data.artists.join(', ')}
+                        </div>
+                    </div>
+
+                    {/* Genre pills */}
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                        {data.genres.map((genre, i) => (
+                            <Pill key={i} tone={i === 0 ? 'clay' : 'neutral'}>{genre}</Pill>
+                        ))}
+                    </div>
+
+                    {/* Star rating */}
+                    <StarRating average={data.rating.average} count={data.rating.count} />
+
+                    {/* Compact condition slider */}
+                    <ConditionSlider
+                        conditionValues={data.originalPriceSuggestion}
+                        selectedCurrency={selectedCurrency}
+                    />
                 </div>
             </div>
-        </div>
-        <div className="mt-4">
-            {props.findRecordResponse.summary && <p>{props.findRecordResponse.summary}</p>}
-        </div></>
 
-    )
+            {/* Wikipedia strip */}
+            {data.summary && (
+                <>
+                    <div style={{ background: 'var(--hairline)', height: 1 }} />
+                    <div style={{ padding: '16px 22px', background: 'var(--soft)' }}>
+                        <div style={{
+                            fontFamily: MONO, fontSize: 10,
+                            letterSpacing: '0.18em', textTransform: 'uppercase',
+                            color: 'var(--muted)', marginBottom: 8,
+                        }}>From Wikipedia</div>
+                        <p style={{ margin: 0, fontSize: 13, lineHeight: 1.55, color: 'var(--dark)' }}>
+                            {data.summary}
+                        </p>
+                    </div>
+                </>
+            )}
+        </div>
+    );
 }

--- a/app/search/components/ConditionSlider.tsx
+++ b/app/search/components/ConditionSlider.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Condition, ConditionValues } from '@/types/discogs';
 import { Currency, currencyOptions } from '@/types/currency';
 import { useCurrency } from '@/app/currency-provider';
+import { staatliches } from '@/styles/fonts';
 
 const CONDITIONS = [
     { condition: Condition.Poor,         label: 'Poor' },
@@ -17,6 +18,8 @@ const CONDITIONS = [
 ];
 
 const DEFAULT_INDEX = 5; // Very Good+
+
+const MONO = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace';
 
 interface ConditionSliderProps {
     conditionValues: ConditionValues | null;
@@ -33,27 +36,41 @@ export default function ConditionSlider({ conditionValues, selectedCurrency }: C
     const rawPrice = conditionValues[selected.condition].value;
     const convertedPrice = Math.round(rawPrice * rates[selectedCurrency]);
     const symbol = currencyOptions[selectedCurrency].symbol;
+    const pct = (selectedIndex / (CONDITIONS.length - 1)) * 100;
 
     return (
-        <div className="flex flex-col items-center gap-2">
-            <p className="text-center">
-                <span className="text-lg font-bold">{symbol}{convertedPrice}</span>
-            </p>
-            <div className="flex w-full flex-col gap-1">
-                <span className="text-xs text-gray-500 text-center">Condition</span>
-                <div className="flex w-full items-center gap-2">
-                    <span className="text-xs text-gray-500">Poor</span>
-                    <input
-                        type="range"
-                        min={0}
-                        max={7}
-                        step={1}
-                        value={selectedIndex}
-                        onChange={(e) => setSelectedIndex(Number(e.target.value))}
-                        className="range range-xs flex-1"
-                    />
-                    <span className="text-xs text-gray-500">Mint</span>
-                </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
+                <div style={{
+                    fontFamily: MONO,
+                    fontSize: 10, letterSpacing: '0.16em',
+                    textTransform: 'uppercase', color: 'var(--muted)',
+                }}>Condition</div>
+                <div style={{
+                    fontFamily: staatliches.style.fontFamily,
+                    fontSize: 24, lineHeight: 1,
+                    color: 'var(--clay)', fontVariantNumeric: 'tabular-nums',
+                }}>{symbol}{convertedPrice}</div>
+            </div>
+            <input
+                type="range"
+                min={0}
+                max={CONDITIONS.length - 1}
+                step={1}
+                value={selectedIndex}
+                onChange={(e) => setSelectedIndex(Number(e.target.value))}
+                className="cm-range"
+                style={{ '--cm-fill': `${pct}%` } as React.CSSProperties}
+                aria-label="Condition"
+            />
+            <div style={{
+                display: 'flex', justifyContent: 'space-between',
+                fontFamily: MONO,
+                fontSize: 9, letterSpacing: '0.14em',
+                color: 'var(--muted)', textTransform: 'uppercase',
+            }}>
+                <span>Poor</span>
+                <span>Mint</span>
             </div>
         </div>
     );

--- a/app/search/components/ConditionSlider.tsx
+++ b/app/search/components/ConditionSlider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Condition, ConditionValues } from '@/types/discogs';
 import { Currency, currencyOptions } from '@/types/currency';
 import { useCurrency } from '@/app/currency-provider';

--- a/components/StarRating.tsx
+++ b/components/StarRating.tsx
@@ -1,44 +1,57 @@
-import React from "react";
+import React from 'react';
 
 interface StarRatingProps {
     count: number;
     average: number;
 }
 
+function StarSvg({ size, color }: { size: number; color: string }) {
+    return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill={color} aria-hidden={true}>
+            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 22 12 18.56 5.82 22 7 14.14l-5-4.87 6.91-1.01z" />
+        </svg>
+    );
+}
+
 const StarRating: React.FC<StarRatingProps> = ({ count, average }) => {
+    if (!count) {
+        return <span style={{ fontSize: 12, color: 'var(--muted)' }}>No reviews</span>;
+    }
 
-    if (count === 0 || count === undefined) {
-        console.log("No reviews yet");
-        return <p className="text-sm text-gray-500 text-center">No reviews</p>;
-      }
-  // Ensure the rating is between 0 and 5 and round to the nearest 0.5
-  const roundedRating = Math.min(5, Math.max(0, Math.round(average * 2) / 2));
+    const size = 14;
+    const rounded = Math.min(5, Math.max(0, Math.round(average * 2) / 2));
 
-
-
-  return (
-    <div className="rating rating-md rating-half mx-auto">
-      {[...Array(10)].map((_, index) => {
-        // Determine if this half-star should be checked
-        const halfValue = (index + 1) / 2;
-        const isChecked = roundedRating === halfValue;
-
-        return (
-          <input
-            key={index}
-            type="radio"
-            name="rating"
-            className={`mask mask-star-2 ${
-              index % 2 === 0 ? "mask-half-1" : "mask-half-2"
-            } bg-orange-500`}
-            checked={isChecked}
-            readOnly
-            style={{ cursor: "default" }}
-          />
-        );
-      })}
-    </div>
-  );
+    return (
+        <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <div
+                style={{ display: 'inline-flex', gap: 1 }}
+                aria-label={`${average} out of 5`}
+                role="img"
+            >
+                {[0, 1, 2, 3, 4].map(i => {
+                    const fill = Math.max(0, Math.min(1, rounded - i));
+                    return (
+                        <span
+                            key={i}
+                            style={{ position: 'relative', width: size, height: size, display: 'inline-block' }}
+                        >
+                            <StarSvg size={size} color="#dcd6c8" />
+                            <span style={{
+                                position: 'absolute', left: 0, top: 0,
+                                width: `${fill * 100}%`, height: '100%', overflow: 'hidden',
+                            }}>
+                                <StarSvg size={size} color="var(--star)" />
+                            </span>
+                        </span>
+                    );
+                })}
+            </div>
+            <span style={{ fontSize: 12, color: 'var(--muted)', fontVariantNumeric: 'tabular-nums' }}>
+                {average.toFixed(1)}{' '}
+                <span style={{ opacity: 0.65 }}>· {count.toLocaleString()}</span>
+            </span>
+        </div>
+    );
 };
 
 export default StarRating;

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -107,7 +107,7 @@ test('submitting a search triggers loading state then renders AlbumTile', async 
   await page.click('button[type="submit"]');
 
   await expect(page.locator('button[type="submit"] .loading')).toBeVisible();
-  await expect(page.locator('.card-title')).toHaveText('Abbey Road', { timeout: 10_000 });
+  await expect(page.locator('h2')).toHaveText('Abbey Road', { timeout: 10_000 });
   await expect(page.locator('input[type="range"]')).toBeVisible();
   // VG+ default: value=30, USD rate=1 → $30
   await expect(page.getByText('$30')).toBeVisible();


### PR DESCRIPTION
## What was built and why

Implements the Variant B design from a Claude Design handoff session. The previous AlbumTile used generic DaisyUI card classes that clashed with the site's minimal lofi aesthetic (indigo-800 year stat, neon-green success badges, DaisyUI radio star inputs). The redesign brings the component in line with the header's visual language.

## Key decisions

- **Layout**: 200 px cover top-aligned left, right column with all metadata — matches the "compact split" that read best with the real album art dimensions
- **Type**: Staatliches (already loaded for the header wordmark) for the album title and condition price; system monospace for labels/meta lines — no new font requests
- **Palette**: existing lofi neutrals + one restrained terracotta accent (`oklch(0.58 0.12 45)`) for the price and slider fill; orange star colour unchanged
- **ConditionSlider**: "Condition" / price inline on one row, custom `.cm-range` CSS replaces the DaisyUI `range` class, Poor → Mint endpoint labels only (no Discogs-specific jargon in the UI)
- **StarRating**: rewritten with SVG half-fill stars instead of DaisyUI radio inputs — simpler, no hidden form state
- **CSS variables**: `--clay`, `--clay-soft`, `--clay-ink`, `--muted`, `--soft`, `--hairline`, `--dark`, `--star` added to `:root` in `globals.css` so they're available to the range slider's `::-webkit-slider-runnable-track` pseudo-element (which Tailwind utilities can't reach)

## Known vulnerabilities

PostCSS `8.4.31` (moderate, GHSA-qx2v-qp2m-jg93) — pre-existing on `main`, not introduced by this branch. The forced fix requires downgrading Next.js to 9.x, which is not viable.