### PR TITLE
chore: upgrade typescript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "postcss": "^8.4.38",
         "tailwindcss": "^4.3.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.4.3"
+        "typescript": "^6.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -12680,10 +12680,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^4.3.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.3"
+    "typescript": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `typescript` devDependency from `^5.4.3` to `^6.0.0` (installs 6.0.3)
- Zero type errors with `tsc --noEmit`, all 80 Jest tests pass, lint clean

## Key decisions

Pre-upgrade impact assessment found no breaking patterns in the codebase: no `const enum`, no namespaces, no decorators, no `import ... assert` syntax, and `moduleResolution: bundler` is valid in TS6. The two `export enum` declarations (`Currency`, `Condition`) are regular enums and fully supported. The only theoretical risk — latent type errors surfaced by TS6's improved narrowing — turned out to be zero.

## Known vulnerabilities

Pre-existing moderate CVE in `postcss@8.4.31` (nested inside `next`'s own dependency tree, not introduced by this branch): GHSA-qx2v-qp2m-jg93. Fix requires downgrading Next.js to 9.x, which is not viable. No action taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)