### PR TITLE
chore: upgrade deps — react-tooltip v6, nextjs-toploader v3, remove unused direct deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,15 @@
         "@heroicons/react": "^2.2.0",
         "@sentry/nextjs": "^10.52.0",
         "next": "^16.2.6",
-        "nextjs-toploader": "^1.6.11",
+        "nextjs-toploader": "^3.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.75.0",
         "react-hot-toast": "^2.6.0",
-        "react-tooltip": "^5.26.3",
-        "wikipedia": "^2.4.2",
-        "zod": "^3.22.4"
+        "react-tooltip": "^6.0.2",
+        "wikipedia": "^2.4.2"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "^3.0.0",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.3.0",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1056,26 +1054,29 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.0.0",
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@heroicons/react": {
       "version": "2.2.0",
@@ -4529,11 +4530,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/nprogress": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.3.tgz",
-      "integrity": "sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA=="
-    },
     "node_modules/@types/pg": {
       "version": "8.15.6",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
@@ -6090,11 +6086,6 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "license": "MIT"
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
-    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -6167,6 +6158,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -10252,16 +10252,16 @@
       }
     },
     "node_modules/nextjs-toploader": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/nextjs-toploader/-/nextjs-toploader-1.6.11.tgz",
-      "integrity": "sha512-2mt+YDj3I7s8JGv136TRdJo9amd2BBeb2u1U4tyvZpR08eqeBgqp3xsw2Yu1AUT7C3NZQhbQN11EXwnlqsPEIA==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/nextjs-toploader/-/nextjs-toploader-3.9.17.tgz",
+      "integrity": "sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw==",
+      "license": "MIT",
       "dependencies": {
-        "@types/nprogress": "^0.2.2",
         "nprogress": "^0.2.0",
         "prop-types": "^15.8.1"
       },
       "funding": {
-        "url": "https://github.com/sponsors/TheSGJ"
+        "url": "https://buymeacoffee.com/thesgj"
       },
       "peerDependencies": {
         "next": ">= 6.0.0",
@@ -11150,12 +11150,13 @@
       "license": "MIT"
     },
     "node_modules/react-tooltip": {
-      "version": "5.26.3",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.26.3.tgz",
-      "integrity": "sha512-MpYAws8CEHUd/RC4GaDCdoceph/T4KHM5vS5Dbk8FOmLMvvIht2ymP2htWdrke7K6lqPO8rz8+bnwWUIXeDlzg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-6.0.2.tgz",
+      "integrity": "sha512-34/RxCkIu+MzIUGZIdRr/BR6heuopU1m1k8EeVEkApFQdloM8nzgYdiigrJ/DniCoMHyx/PcFe0pbG2MtlDwnw==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.6.1",
-        "classnames": "^2.3.0"
+        "@floating-ui/dom": "1.7.6",
+        "clsx": "2.1.1"
       },
       "peerDependencies": {
         "react": ">=16.14.0",
@@ -13385,6 +13386,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -16,17 +16,15 @@
     "@heroicons/react": "^2.2.0",
     "@sentry/nextjs": "^10.52.0",
     "next": "^16.2.6",
-    "nextjs-toploader": "^1.6.11",
+    "nextjs-toploader": "^3.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.75.0",
     "react-hot-toast": "^2.6.0",
-    "react-tooltip": "^5.26.3",
-    "wikipedia": "^2.4.2",
-    "zod": "^3.22.4"
+    "react-tooltip": "^6.0.2",
+    "wikipedia": "^2.4.2"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.0.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## What changed

Four dependency changes consolidated from parallel work:

- **react-tooltip `^5` → `^6`** — the only breaking change in v6 is removal of the `html` prop / `data-tooltip-html` attribute (for raw HTML injection). This project uses neither; it uses only `data-tooltip-content` and `data-tooltip-id`, both unchanged.
- **nextjs-toploader `^1.6.11` → `^3.0.0`** — major bump.
- **Remove `zod` from direct dependencies** — not imported anywhere in source; was only present as a transitive dependency of Next.js. Continues to be available transitively.
- **Remove `@eslint/eslintrc` from devDependencies** — not referenced in `eslint.config.mjs` (ESLint 9 flat config doesn't need it).

## API compatibility note

No source files required changes. `components/LayoutClient.tsx` (`<Tooltip id="tooltip" .../>`) and `app/search/components/RecordSearchForm.tsx` (`data-tooltip-id`, `data-tooltip-content`) are fully compatible with react-tooltip v6.

## Security gate

- `npm audit --omit=dev --audit-level=high` → exit 0
- 2 moderate findings remain (PostCSS XSS via Next.js internals — pre-existing, unfixable without downgrading Next to 9.x)
- No new `NEXT_PUBLIC_` variable exposure

## Test results

- Jest: **80/80 passed** (10 suites)
- Playwright e2e: **7/7 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)