### PR TITLE
feat: invert scan button — black background, white text

### DIFF
--- a/app/search/components/CameraButton.tsx
+++ b/app/search/components/CameraButton.tsx
@@ -121,8 +121,8 @@ export default function CameraButton({ onRecordSearch, onLoadingChange }: Camera
         onClick={() => fileInputRef.current?.click()}
         disabled={loading}
         style={{
-          height: 52, background: 'transparent', color: 'var(--ink)',
-          boxShadow: 'inset 0 0 0 1px var(--ink)', border: 'none',
+          height: 52, background: 'var(--ink)', color: '#fff',
+          boxShadow: 'none', border: 'none',
           fontFamily: MONO, fontSize: 12, letterSpacing: '0.18em',
           textTransform: 'uppercase', cursor: loading ? 'default' : 'pointer',
           borderRadius: 2, opacity: loading ? 0.6 : 1,


### PR DESCRIPTION
## Summary
- Changes the Scan a cover button from outline (transparent bg, dark border) to solid black (`var(--ink)`) with white text, giving it stronger visual weight relative to the search Find button.

## Known vulnerabilities
Pre-existing on `main` (not introduced by this branch): 2 moderate CVEs in `next` → `postcss`. Fix requires downgrading Next.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)