### PR TITLE
feat: default EUR, de-emphasise currency selector

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,7 +136,7 @@ function LoadingState() {
 export default function Home() {
   const [resultState, setResultState] = useState<ResultState>('empty');
   const [findRecordResponse, setRecordResponse] = useState<ReleaseData | undefined>();
-  const [selectedCurrency, setSelectedCurrency] = useState<Currency>(Currency.USD);
+  const [selectedCurrency, setSelectedCurrency] = useState<Currency>(Currency.EUR);
 
   const handleRecordSearch = (data: ReleaseData) => {
     setRecordResponse(data);
@@ -165,32 +165,13 @@ export default function Home() {
               padding: '28px 32px',
               overflow: 'hidden',
             }}>
-              <div style={{
-                display: 'flex', alignItems: 'center',
-                justifyContent: 'space-between', flexWrap: 'wrap', gap: 8, marginBottom: 14,
-              }}>
+              <div style={{ marginBottom: 14 }}>
                 <span style={{
                   fontFamily: MONO, fontSize: 10, letterSpacing: '0.18em',
                   textTransform: 'uppercase', color: 'var(--muted)',
                 }}>
                   Search · by title or artist
                 </span>
-                <div style={{
-                  display: 'inline-flex', alignItems: 'center', gap: 8,
-                  padding: '6px 10px',
-                  boxShadow: 'inset 0 0 0 1px var(--hairline)',
-                  borderRadius: 2,
-                  maxWidth: '100%',
-                }}>
-                  <span style={{
-                    fontFamily: MONO, fontSize: 9, letterSpacing: '0.2em',
-                    textTransform: 'uppercase', color: 'var(--muted)',
-                    flexShrink: 0,
-                  }}>
-                    Currency
-                  </span>
-                  <CurrencySelector onCurrencyChange={setSelectedCurrency} />
-                </div>
               </div>
 
               <LookUpForm
@@ -222,10 +203,18 @@ export default function Home() {
               fontFamily: MONO, fontSize: 10,
               letterSpacing: '0.16em', textTransform: 'uppercase',
               color: 'var(--muted)',
-              display: 'flex', justifyContent: 'space-between',
+              display: 'flex', justifyContent: 'space-between', alignItems: 'center',
             }}>
-              <span>Data · Discogs API</span>
-              <span>Notes · Wikipedia</span>
+              <span>Discogs · Wikipedia</span>
+              <CurrencySelector
+                onCurrencyChange={setSelectedCurrency}
+                selectStyle={{
+                  appearance: 'none', border: 'none', background: 'transparent',
+                  fontFamily: MONO, fontSize: 10, letterSpacing: '0.16em',
+                  textTransform: 'uppercase', color: 'var(--muted)',
+                  cursor: 'pointer', maxWidth: 60,
+                }}
+              />
             </div>
           </div>
 

--- a/components/CurrencySelector.tsx
+++ b/components/CurrencySelector.tsx
@@ -1,28 +1,31 @@
-import { Currency, currencyOptions } from "@/types/currency";
+import { Currency } from "@/types/currency";
 import React from "react";
 
 interface CurrencySelectorProps {
-    onCurrencyChange: (_currency: Currency) => void;
-  }
-
-export const CurrencySelector: React.FC<CurrencySelectorProps> = ({ onCurrencyChange }) => {
-    const [selectedCurrency, setSelectedCurrency] = React.useState('USD'); // Default to USD
-    
-      const handleCurrencyChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        const selectedCurrency = event.target.value as Currency;
-        if (selectedCurrency) {
-            setSelectedCurrency(selectedCurrency);
-            onCurrencyChange(selectedCurrency);
-        }
-      };
-    
-      return (
-        <select value={selectedCurrency} onChange={handleCurrencyChange} style={{ maxWidth: '100%' }}>
-          {Object.values(Currency).map((currency) => (
-            <option key={currency} value={currency}>
-              {currencyOptions[currency].label} / {currencyOptions[currency].symbol}
-            </option>
-          ))}
-        </select>
-      );
+  onCurrencyChange: (_currency: Currency) => void;
+  selectStyle?: React.CSSProperties;
 }
+
+export const CurrencySelector: React.FC<CurrencySelectorProps> = ({ onCurrencyChange, selectStyle }) => {
+  const [selectedCurrency, setSelectedCurrency] = React.useState<Currency>(Currency.EUR);
+
+  const handleCurrencyChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value as Currency;
+    if (value) {
+      setSelectedCurrency(value);
+      onCurrencyChange(value);
+    }
+  };
+
+  return (
+    <select
+      value={selectedCurrency}
+      onChange={handleCurrencyChange}
+      style={{ maxWidth: '100%', ...selectStyle }}
+    >
+      {Object.values(Currency).map((currency) => (
+        <option key={currency} value={currency}>{currency}</option>
+      ))}
+    </select>
+  );
+};

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -109,8 +109,8 @@ test('submitting a search triggers loading state then renders AlbumTile', async 
   await expect(page.locator('button[type="submit"] .loading')).toBeVisible();
   await expect(page.locator('h2')).toHaveText('Abbey Road', { timeout: 10_000 });
   await expect(page.locator('input[type="range"]')).toBeVisible();
-  // VG+ default: value=30, USD rate=1 → $30
-  await expect(page.getByText('$30')).toBeVisible();
+  // VG+ default: value=30, EUR rate=0.92 → €28
+  await expect(page.getByText('€28')).toBeVisible();
 });
 
 test('currency selector is visible and changing it does not crash the page', async ({ page }) => {


### PR DESCRIPTION
## What changed

- **Default currency**: EUR instead of USD
- **Currency selector removed from search panel** header — was a visually prominent chip that distracted from the primary search action
- **Currency selector relocated** to the attribution row below the panel ("Discogs · Wikipedia"), styled as plain muted 10 px mono text — same visual weight as the data-source attribution
- **Options simplified** to 3-letter code only (EUR, GBP, etc.) — minimal and unambiguous for the expected audience
- **e2e test updated** to assert €28 at VG+ (EUR 0.92 × $30) instead of $30

## Why

Currency is a low-frequency preference, not a primary input. Moving it out of the search flow and into the footer-adjacent attribution area keeps it accessible without demanding attention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)