### PR TITLE
fix: stack album tile vertically on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -182,6 +182,50 @@
   .cm-result-col { max-width: 640px; margin: 0 auto; width: 100%; }
 }
 
+/* Album tile — responsive cover + info layout */
+.cm-tile-inner {
+  display: flex;
+  padding: 22px;
+  gap: 22px;
+  align-items: flex-start;
+}
+
+.cm-tile-cover {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.cm-tile-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+@media (max-width: 600px) {
+  .cm-tile-inner {
+    flex-direction: column;
+    padding: 0;
+    gap: 0;
+  }
+
+  .cm-tile-cover {
+    width: 100%;
+    height: 260px;
+    flex-shrink: unset;
+  }
+
+  .cm-tile-info {
+    padding: 16px 18px;
+    flex: none;
+    min-width: unset;
+  }
+}
+
 @keyframes cm-pulse { 0%, 100% { opacity: 0.55 } 50% { opacity: 1 } }
 
 html,

--- a/app/search/components/AlbumTile.tsx
+++ b/app/search/components/AlbumTile.tsx
@@ -34,9 +34,9 @@ export default function AlbumTile({ findRecordResponse: data, selectedCurrency }
             background: '#fff',
             boxShadow: '0 1px 0 var(--hairline), 0 12px 28px -16px rgba(60,50,40,0.25)',
         }}>
-            <div style={{ display: 'flex', padding: 22, gap: 22, alignItems: 'flex-start' }}>
+            <div className="cm-tile-inner">
                 {/* Cover art */}
-                <div style={{ position: 'relative', width: 200, height: 200, flexShrink: 0, overflow: 'hidden' }}>
+                <div className="cm-tile-cover">
                     <Image
                         src={data.image}
                         alt={`Album art for ${data.title}`}
@@ -46,7 +46,7 @@ export default function AlbumTile({ findRecordResponse: data, selectedCurrency }
                 </div>
 
                 {/* Right column */}
-                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 14 }}>
+                <div className="cm-tile-info">
                     {/* Year · tracks meta */}
                     <div style={{
                         fontFamily: MONO, fontSize: 10,

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -151,3 +151,46 @@ test('layout has no horizontal overflow at 390×844 (iPhone 14)', async ({ page 
   }));
   expect(docScrollWidth).toBeLessThanOrEqual(innerWidth);
 });
+
+async function renderAlbumTile(page: import('@playwright/test').Page) {
+  await page.route('/', async (route) => {
+    if (
+      route.request().method() === 'POST' &&
+      route.request().headers()['next-action']
+    ) {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'content-type': 'text/x-component',
+          'x-action-revalidated': '[[],0,0]',
+        },
+        body: RSC_ACTION_BODY,
+      });
+    } else {
+      await route.continue();
+    }
+  });
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  await page.fill('#search', 'Abbey Road');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('h2')).toHaveText('Abbey Road', { timeout: 10_000 });
+}
+
+test('AlbumTile stacks vertically (flex-direction: column) at 390px viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await renderAlbumTile(page);
+  const flexDirection = await page.locator('.cm-tile-inner').evaluate(
+    (el) => getComputedStyle(el).flexDirection
+  );
+  expect(flexDirection).toBe('column');
+});
+
+test('AlbumTile uses row layout (flex-direction: row) at 1200px viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 1200, height: 900 });
+  await renderAlbumTile(page);
+  const flexDirection = await page.locator('.cm-tile-inner').evaluate(
+    (el) => getComputedStyle(el).flexDirection
+  );
+  expect(flexDirection).toBe('row');
+});


### PR DESCRIPTION
## What

On narrow viewports (≤ 600px) the `AlbumTile` right column was only ~60px wide:

```
390px viewport − 64px page padding − 44px card padding − 200px cover − 22px gap = 60px
```

The card's `overflow: hidden` clipped content at that boundary, causing the genre
pills to be cut off and the condition price to be truncated.

## Fix

Moved the three layout-critical divs in `AlbumTile` from inline styles to CSS classes
(`cm-tile-inner`, `cm-tile-cover`, `cm-tile-info`) so a media query can respond. At
`max-width: 600px` the tile flips to a vertical stack: cover expands to full card width
(260px tall, edge-to-edge), and the info section sits below it with its own padding.
Desktop layout is unchanged.

## Known vulnerabilities (pre-existing on main)

- `postcss@8.4.31` (nested in `next`) — moderate severity XSS. Present on `main` before this branch; not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)