### PR TITLE
feat: set condition slider default from camera-estimated sleeve condition

### DIFF
--- a/app/api/identify/route.test.ts
+++ b/app/api/identify/route.test.ts
@@ -1,4 +1,7 @@
-const MOCK_TEXT_BLOCK = { type: 'text', text: 'Pink Floyd - The Dark Side of the Moon' };
+const MOCK_TEXT_BLOCK = {
+  type: 'text',
+  text: '{"query":"Pink Floyd - The Dark Side of the Moon","condition":"Very Good (VG)"}',
+};
 
 let mockCreate: jest.Mock;
 
@@ -27,23 +30,29 @@ afterEach(() => {
 });
 
 describe('POST /api/identify', () => {
-  it('returns 200 and { query } when Claude identifies the album', async () => {
+  it('returns 200 and { query, condition } when Claude identifies the album', async () => {
     const { POST } = await import('./route');
     const res = await POST(makeRequest(makeFile()));
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ query: 'Pink Floyd - The Dark Side of the Moon' });
+    expect(await res.json()).toEqual({
+      query: 'Pink Floyd - The Dark Side of the Moon',
+      condition: 'Very Good (VG)',
+    });
   });
 
-  it('trims whitespace from Claude response', async () => {
+  it('trims whitespace from query inside JSON response', async () => {
     mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'text', text: '  Pink Floyd - The Dark Side of the Moon  \n' }],
+      content: [{ type: 'text', text: '  {"query":"  Pink Floyd - The Dark Side of the Moon  ","condition":null}  \n' }],
     });
 
     const { POST } = await import('./route');
     const res = await POST(makeRequest(makeFile()));
 
-    expect(await res.json()).toEqual({ query: 'Pink Floyd - The Dark Side of the Moon' });
+    expect(await res.json()).toEqual({
+      query: 'Pink Floyd - The Dark Side of the Moon',
+      condition: null,
+    });
   });
 
   it('calls Anthropic with model claude-haiku-4-5 and base64 image source', async () => {
@@ -77,24 +86,59 @@ describe('POST /api/identify', () => {
     );
   });
 
-  it('returns 200 + { query: "UNKNOWN" } when Claude returns "UNKNOWN"', async () => {
-    mockCreate.mockResolvedValueOnce({ content: [{ type: 'text', text: 'UNKNOWN' }] });
+  it('uses max_tokens of at least 200', async () => {
+    const { POST } = await import('./route');
+    await POST(makeRequest(makeFile()));
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.max_tokens).toBeGreaterThanOrEqual(200);
+  });
+
+  it('returns 200 + { query: "UNKNOWN", condition: null } when Claude returns UNKNOWN JSON', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: '{"query":"UNKNOWN","condition":null}' }],
+    });
 
     const { POST } = await import('./route');
     const res = await POST(makeRequest(makeFile()));
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ query: 'UNKNOWN' });
+    expect(await res.json()).toEqual({ query: 'UNKNOWN', condition: null });
   });
 
-  it('returns 200 + { query: "UNKNOWN" } when Claude response has no text block', async () => {
+  it('returns 200 + { query: "UNKNOWN", condition: null } when Claude response has no text block', async () => {
     mockCreate.mockResolvedValueOnce({ content: [] });
 
     const { POST } = await import('./route');
     const res = await POST(makeRequest(makeFile()));
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ query: 'UNKNOWN' });
+    expect(await res.json()).toEqual({ query: 'UNKNOWN', condition: null });
+  });
+
+  it('returns condition: null when Claude returns null for condition', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: '{"query":"Pink Floyd - The Dark Side of the Moon","condition":null}' }],
+    });
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest(makeFile()));
+
+    expect(await res.json()).toEqual({
+      query: 'Pink Floyd - The Dark Side of the Moon',
+      condition: null,
+    });
+  });
+
+  it('returns { query: "UNKNOWN", condition: null } when Claude returns invalid JSON', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'not valid json at all' }],
+    });
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest(makeFile()));
+
+    expect(await res.json()).toEqual({ query: 'UNKNOWN', condition: null });
   });
 
   it('returns 400 when no image field in FormData', async () => {

--- a/app/api/identify/route.ts
+++ b/app/api/identify/route.ts
@@ -4,9 +4,25 @@ import Anthropic from '@anthropic-ai/sdk';
 const anthropic = new Anthropic();
 
 const SYSTEM_PROMPT =
-  'You are a vinyl record identification assistant. When shown an image of a record album cover, ' +
-  'respond with ONLY the artist name and album title in this exact format: "Artist - Album Title". ' +
-  'If you cannot identify the record, respond with exactly: UNKNOWN. Do not include any other text.';
+  'You are a vinyl record identification and condition assessment assistant.\n' +
+  'When shown an image of a record sleeve, respond with a single JSON object\n' +
+  'and nothing else — no markdown fences, no commentary.\n\n' +
+  'The object must have exactly two keys:\n' +
+  '  "query": the artist and album title in the format "Artist - Album Title",\n' +
+  '            or the string "UNKNOWN" if you cannot identify the record.\n' +
+  '  "condition": one of the following exact strings if sleeve wear is visible\n' +
+  '               and assessable, otherwise null:\n' +
+  '    "Mint (M)"\n' +
+  '    "Near Mint (NM or M-)"\n' +
+  '    "Very Good Plus (VG+)"\n' +
+  '    "Very Good (VG)"\n' +
+  '    "Good Plus (G+)"\n' +
+  '    "Good (G)"\n' +
+  '    "Fair (F)"\n' +
+  '    "Poor (P)"\n\n' +
+  'Base the condition estimate on visible sleeve wear: writing, ring wear,\n' +
+  'seam splits, staining, and creasing. If the image does not show enough\n' +
+  'of the sleeve to assess condition, set "condition" to null.';
 
 export async function POST(req: Request) {
   const formData = await req.formData();
@@ -23,7 +39,7 @@ export async function POST(req: Request) {
 
     const message = await anthropic.messages.create({
       model: 'claude-haiku-4-5',
-      max_tokens: 100,
+      max_tokens: 200,
       system: [
         {
           type: 'text',
@@ -49,9 +65,22 @@ export async function POST(req: Request) {
     });
 
     const textBlock = message.content.find((block) => block.type === 'text') as Anthropic.TextBlock | undefined;
-    const query = textBlock ? textBlock.text.trim() : 'UNKNOWN';
+    const raw = textBlock ? textBlock.text.trim() : null;
 
-    return NextResponse.json({ query });
+    let query = 'UNKNOWN';
+    let condition: string | null = null;
+
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as { query?: unknown; condition?: unknown };
+        if (typeof parsed.query === 'string') query = parsed.query.trim();
+        if (typeof parsed.condition === 'string') condition = parsed.condition;
+      } catch {
+        query = 'UNKNOWN';
+      }
+    }
+
+    return NextResponse.json({ query, condition });
   } catch (error) {
     console.error('Failed to identify record:', error);
     return NextResponse.json({ error: 'Failed to identify record' }, { status: 500 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import CameraButton from '@/app/search/components/CameraButton';
 import { ReleaseData } from '@/app/search/search-service';
 import { CurrencySelector } from '@/components/CurrencySelector';
 import { Currency } from '@/types/currency';
+import { Condition } from '@/types/discogs';
 import { staatliches } from '@/styles/fonts';
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace';
@@ -137,9 +138,11 @@ export default function Home() {
   const [resultState, setResultState] = useState<ResultState>('empty');
   const [findRecordResponse, setRecordResponse] = useState<ReleaseData | undefined>();
   const [selectedCurrency, setSelectedCurrency] = useState<Currency>(Currency.EUR);
+  const [estimatedCondition, setEstimatedCondition] = useState<Condition | null>(null);
 
-  const handleRecordSearch = (data: ReleaseData) => {
+  const handleRecordSearch = (data: ReleaseData, condition: Condition | null = null) => {
     setRecordResponse(data);
+    setEstimatedCondition(condition);
     setResultState('result');
   };
 
@@ -225,6 +228,7 @@ export default function Home() {
               <AlbumTile
                 findRecordResponse={findRecordResponse}
                 selectedCurrency={selectedCurrency}
+                estimatedCondition={estimatedCondition}
               />
             )}
           </div>

--- a/app/search/components/AlbumTile.test.tsx
+++ b/app/search/components/AlbumTile.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AlbumTile from './AlbumTile';
+import { Condition, ConditionValues } from '@/types/discogs';
+import { Currency } from '@/types/currency';
+import { ReleaseData } from '@/app/search/search-service';
+
+jest.mock('@/app/currency-provider', () => ({
+  useCurrency: jest.fn(),
+}));
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: function Image({ alt }: { alt: string }) {
+    return <img alt={alt} />; // eslint-disable-line @next/next/no-img-element
+  },
+}));
+jest.mock('@/components/StarRating', () => ({
+  __esModule: true,
+  default: function StarRating() { return null; },
+}));
+
+import { useCurrency } from '@/app/currency-provider';
+
+const MOCK_CONDITIONS: ConditionValues = {
+  [Condition.Mint]: { currency: 'USD', value: 50 },
+  [Condition.NearMint]: { currency: 'USD', value: 40 },
+  [Condition.VeryGoodPlus]: { currency: 'USD', value: 30 },
+  [Condition.VeryGood]: { currency: 'USD', value: 20 },
+  [Condition.GoodPlus]: { currency: 'USD', value: 15 },
+  [Condition.Good]: { currency: 'USD', value: 10 },
+  [Condition.Fair]: { currency: 'USD', value: 5 },
+  [Condition.Poor]: { currency: 'USD', value: 1 },
+};
+
+const MOCK_RELEASE: ReleaseData = {
+  image: 'https://example.com/cover.jpg',
+  title: 'The Dark Side of the Moon',
+  artists: ['Pink Floyd'],
+  year: 1973,
+  noOfTracks: 10,
+  noForSale: 42,
+  originalPriceSuggestion: MOCK_CONDITIONS,
+  latestPriceSuggestion: 0,
+  genres: ['Rock'],
+  summary: null,
+  rating: { count: 1000, average: 4.9 },
+};
+
+beforeEach(() => {
+  (useCurrency as jest.Mock).mockReturnValue({
+    rates: { USD: 1, EUR: 0.9 },
+    loading: false,
+  });
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('AlbumTile', () => {
+  it('defaults condition slider to VG+ when no estimatedCondition is provided', () => {
+    render(<AlbumTile findRecordResponse={MOCK_RELEASE} selectedCurrency={Currency.USD} />);
+    // VG+ value = 30, USD rate = 1 → $30
+    expect(screen.getByText('$30')).toBeInTheDocument();
+  });
+
+  it('positions condition slider at estimated condition when estimatedCondition is provided', () => {
+    render(<AlbumTile findRecordResponse={MOCK_RELEASE} selectedCurrency={Currency.USD} estimatedCondition={Condition.VeryGood} />);
+    // VeryGood value = 20, USD rate = 1 → $20
+    expect(screen.getByText('$20')).toBeInTheDocument();
+  });
+
+  it('defaults condition slider to VG+ when estimatedCondition is null', () => {
+    render(<AlbumTile findRecordResponse={MOCK_RELEASE} selectedCurrency={Currency.USD} estimatedCondition={null} />);
+    // VG+ value = 30, USD rate = 1 → $30
+    expect(screen.getByText('$30')).toBeInTheDocument();
+  });
+
+  it('renders no condition slider when originalPriceSuggestion is null', () => {
+    const releaseNoPrice = { ...MOCK_RELEASE, originalPriceSuggestion: null } as unknown as ReleaseData;
+    render(<AlbumTile findRecordResponse={releaseNoPrice} selectedCurrency={Currency.USD} />);
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+  });
+});

--- a/app/search/components/AlbumTile.test.tsx
+++ b/app/search/components/AlbumTile.test.tsx
@@ -20,7 +20,7 @@ jest.mock('next/image', () => ({
 }));
 jest.mock('@/components/StarRating', () => ({
   __esModule: true,
-  default: function StarRating() { return null; },
+  default: function StarRating(): null { return null; },
 }));
 
 import { useCurrency } from '@/app/currency-provider';

--- a/app/search/components/AlbumTile.tsx
+++ b/app/search/components/AlbumTile.tsx
@@ -5,12 +5,14 @@ import Image from 'next/image';
 import { ReleaseData } from '../search-service';
 import StarRating from '@/components/StarRating';
 import { Currency } from '@/types/currency';
+import { Condition } from '@/types/discogs';
 import ConditionSlider from './ConditionSlider';
 import { staatliches } from '@/styles/fonts';
 
 interface AlbumTileProps {
     findRecordResponse: ReleaseData;
     selectedCurrency: Currency;
+    estimatedCondition?: Condition | null;
 }
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace';
@@ -27,7 +29,7 @@ function Pill({ children, tone = 'neutral' }: { children: React.ReactNode; tone?
     return <span style={{ ...base, ...toneStyle }}>{children}</span>;
 }
 
-export default function AlbumTile({ findRecordResponse: data, selectedCurrency }: AlbumTileProps) {
+export default function AlbumTile({ findRecordResponse: data, selectedCurrency, estimatedCondition }: AlbumTileProps) {
     return (
         <div style={{
             borderRadius: 4, overflow: 'hidden',
@@ -84,6 +86,7 @@ export default function AlbumTile({ findRecordResponse: data, selectedCurrency }
                     <ConditionSlider
                         conditionValues={data.originalPriceSuggestion}
                         selectedCurrency={selectedCurrency}
+                        initialCondition={estimatedCondition}
                     />
                 </div>
             </div>

--- a/app/search/components/CameraButton.test.ts
+++ b/app/search/components/CameraButton.test.ts
@@ -1,5 +1,6 @@
 import { handleCameraCapture } from './CameraButton';
 import { findRelease, ReleaseData } from '@/app/search/search-service';
+import { Condition } from '@/types/discogs';
 
 jest.mock('@/app/search/search-service', () => ({ findRelease: jest.fn() }));
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
@@ -39,7 +40,7 @@ beforeEach(() => {
 
   jest.spyOn(global, 'fetch').mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve({ query: 'Pink Floyd - The Dark Side of the Moon' }),
+    json: () => Promise.resolve({ query: 'Pink Floyd - The Dark Side of the Moon', condition: 'Very Good (VG)' }),
   } as Response);
 
   mockFindRelease.mockResolvedValue(MOCK_RELEASE);
@@ -115,7 +116,7 @@ describe('handleCameraCapture', () => {
   it('sets error and skips findRelease when API returns query "UNKNOWN"', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ query: 'UNKNOWN' }),
+      json: () => Promise.resolve({ query: 'UNKNOWN', condition: null }),
     } as Response);
 
     await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
@@ -163,13 +164,46 @@ describe('handleCameraCapture', () => {
     expect(mockFindRelease).toHaveBeenCalledWith('Pink Floyd - The Dark Side of the Moon');
   });
 
-  it('calls onRecordSearch with the ReleaseData from findRelease', async () => {
+  it('calls onRecordSearch with ReleaseData and parsed Condition when condition is valid', async () => {
     await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
 
-    expect(onRecordSearch).toHaveBeenCalledWith(MOCK_RELEASE);
+    expect(onRecordSearch).toHaveBeenCalledWith(MOCK_RELEASE, Condition.VeryGood);
   });
 
-  it('sets "Couldn\'t find this record" error and skips onRecordSearch when findRelease throws', async () => {
+  it('calls onRecordSearch with null condition when API returns null condition', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ query: 'Pink Floyd - The Dark Side of the Moon', condition: null }),
+    } as Response);
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(onRecordSearch).toHaveBeenCalledWith(MOCK_RELEASE, null);
+  });
+
+  it('calls onRecordSearch with null condition when API returns unrecognised condition string', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ query: 'Pink Floyd - The Dark Side of the Moon', condition: 'Excellent' }),
+    } as Response);
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(onRecordSearch).toHaveBeenCalledWith(MOCK_RELEASE, null);
+  });
+
+  it('calls onRecordSearch with null condition when condition field is missing from API response', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ query: 'Pink Floyd - The Dark Side of the Moon' }),
+    } as Response);
+
+    await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);
+
+    expect(onRecordSearch).toHaveBeenCalledWith(MOCK_RELEASE, null);
+  });
+
+  it("sets \"Couldn't find this record\" error and skips onRecordSearch when findRelease throws", async () => {
     mockFindRelease.mockRejectedValueOnce(new Error('Not found'));
 
     await handleCameraCapture(makeFile(), onRecordSearch, setLoading, setError);

--- a/app/search/components/CameraButton.tsx
+++ b/app/search/components/CameraButton.tsx
@@ -2,15 +2,23 @@
 
 import { ChangeEvent, useRef, useState } from 'react';
 import { findRelease, ReleaseData } from '@/app/search/search-service';
+import { Condition } from '@/types/discogs';
 import { resizeImage } from './resize-image';
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace';
 
 const MAX_FILE_SIZE = 52_428_800; // 50 MB — hard cap before canvas resize
 
+const VALID_CONDITIONS = new Set<string>(Object.values(Condition));
+
+function parseCondition(raw: string | null | undefined): Condition | null {
+  if (!raw) return null;
+  return VALID_CONDITIONS.has(raw) ? (raw as Condition) : null;
+}
+
 export async function handleCameraCapture(
   file: File | null | undefined,
-  onRecordSearch: (_data: ReleaseData) => void,
+  onRecordSearch: (_data: ReleaseData, _condition: Condition | null) => void,
   setLoading: (_loading: boolean) => void,
   setError: (_error: string) => void,
   onLoadingChange?: (_loading: boolean) => void,
@@ -26,6 +34,7 @@ export async function handleCameraCapture(
   onLoadingChange?.(true);
 
   let query: string;
+  let condition: Condition | null = null;
   try {
     const resized = await resizeImage(file);
     const compressed = new File([resized], file.name, { type: 'image/jpeg' });
@@ -51,6 +60,7 @@ export async function handleCameraCapture(
     }
 
     query = body.query as string;
+    condition = parseCondition(body.condition ?? null);
   } catch {
     setError('Network error — check your connection');
     setLoading(false);
@@ -67,7 +77,7 @@ export async function handleCameraCapture(
 
   try {
     const data = await findRelease(query);
-    onRecordSearch(data);
+    onRecordSearch(data, condition);
   } catch {
     setError("Couldn't find this record in the database — try searching manually");
     setLoading(false);
@@ -80,7 +90,7 @@ export async function handleCameraCapture(
 }
 
 interface CameraButtonProps {
-  onRecordSearch: (_data: ReleaseData) => void;
+  onRecordSearch: (_data: ReleaseData, _condition: Condition | null) => void;
   onLoadingChange?: (_loading: boolean) => void;
 }
 

--- a/app/search/components/ConditionSlider.test.tsx
+++ b/app/search/components/ConditionSlider.test.tsx
@@ -76,4 +76,21 @@ describe('ConditionSlider', () => {
     // VG+ value=30, GBP rate=0.79: Math.round(30 * 0.79) = 24
     expect(screen.getByText('£24')).toBeInTheDocument();
   });
+
+  it('defaults to estimated condition when initialCondition is Condition.VeryGood', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} initialCondition={Condition.VeryGood} />);
+    // VeryGood value = 20, USD rate = 1 → $20
+    expect(screen.getByText('$20')).toBeInTheDocument();
+  });
+
+  it('defaults to VG+ when initialCondition is null', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} initialCondition={null} />);
+    // VG+ value = 30, USD rate = 1 → $30
+    expect(screen.getByText('$30')).toBeInTheDocument();
+  });
+
+  it('defaults to VG+ when initialCondition is not provided', () => {
+    render(<ConditionSlider conditionValues={mockConditionValues} selectedCurrency={Currency.USD} />);
+    expect(screen.getByText('$30')).toBeInTheDocument();
+  });
 });

--- a/app/search/components/ConditionSlider.tsx
+++ b/app/search/components/ConditionSlider.tsx
@@ -21,13 +21,20 @@ const DEFAULT_INDEX = 5; // Very Good+
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace';
 
+function getInitialIndex(condition: Condition | null | undefined): number {
+    if (!condition) return DEFAULT_INDEX;
+    const idx = CONDITIONS.findIndex(c => c.condition === condition);
+    return idx >= 0 ? idx : DEFAULT_INDEX;
+}
+
 interface ConditionSliderProps {
     conditionValues: ConditionValues | null;
     selectedCurrency: Currency;
+    initialCondition?: Condition | null;
 }
 
-export default function ConditionSlider({ conditionValues, selectedCurrency }: ConditionSliderProps) {
-    const [selectedIndex, setSelectedIndex] = useState(DEFAULT_INDEX);
+export default function ConditionSlider({ conditionValues, selectedCurrency, initialCondition }: ConditionSliderProps) {
+    const [selectedIndex, setSelectedIndex] = useState(() => getInitialIndex(initialCondition));
     const { rates } = useCurrency();
 
     if (!conditionValues) return null;

--- a/app/search/components/RecordSearchForm.tsx
+++ b/app/search/components/RecordSearchForm.tsx
@@ -3,11 +3,12 @@
 import { ReleaseData, findRelease } from '@/app/search/search-service';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { useState } from 'react';
+import { Condition } from '@/types/discogs';
 
 const MONO = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace';
 
 interface LookUpFormProps {
-  onRecordSearch: (_data: ReleaseData) => void;
+  onRecordSearch: (_data: ReleaseData, _condition?: Condition | null) => void;
   onLoadingChange?: (_loading: boolean) => void;
 }
 

--- a/types/discogs.ts
+++ b/types/discogs.ts
@@ -127,3 +127,8 @@ export type ConditionValues = {
         value: number;
     };
 };
+
+export interface IdentifyResponse {
+    query: string;
+    condition: string | null;
+}


### PR DESCRIPTION
## What was built and why

When a user scans a cover, the Claude Haiku vision call now also assesses visible sleeve wear and returns a condition string alongside the query. This threads all the way through to the `ConditionSlider`, which opens at the estimated condition (e.g. Very Good) instead of always defaulting to VG+. This makes the price shown immediately relevant to the actual copy in the user's hands. The text-search path is completely unaffected — the slider still defaults to VG+ when no condition is provided.

## Key decisions

- **Reuses the existing vision call** — the system prompt is extended to JSON output; no new API endpoint, no extra Discogs calls, no new dependencies.
- **Slider not replaced** — the ConditionSlider remains interactive. `initialCondition` just sets the starting index; the user can still slide to compare all conditions.
- **Enum validation in CameraButton** — the raw string from the API is validated against `Object.values(Condition)` before use. Unrecognised strings fall back to `null` → VG+ default.
- **`condition` is `string | null` at the API boundary** (`IdentifyResponse`), only typed as `Condition | null` after validation in `CameraButton`.

## Test coverage

- `route.test.ts` — JSON parsing, condition pass-through, null condition, invalid JSON, max_tokens ≥ 200
- `CameraButton.test.ts` — valid condition forwarded, null forwarded, unrecognised string → null, missing field → null
- `ConditionSlider.test.tsx` — slider defaults to `initialCondition` index, falls back to VG+ on null/absent
- `AlbumTile.test.tsx` (new) — slider position driven by `estimatedCondition` prop; null/absent → VG+; no slider when `originalPriceSuggestion` is null

## Known vulnerabilities

- `postcss <8.5.10` (moderate, GHSA-qx2v-qp2m-jg93) — pre-existing on `main`, not introduced by this branch. Fix requires `next@9.3.3` which is a breaking downgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)