### PR TITLE
refactor: remove eslint-disable from Image mock

### DIFF
--- a/app/search/components/AlbumTile.test.tsx
+++ b/app/search/components/AlbumTile.test.tsx
@@ -14,9 +14,7 @@ jest.mock('@/app/currency-provider', () => ({
 }));
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: function Image({ alt }: { alt: string }) {
-    return <img alt={alt} />; // eslint-disable-line @next/next/no-img-element
-  },
+  default: function Image(): null { return null; },
 }));
 jest.mock('@/components/StarRating', () => ({
   __esModule: true,


### PR DESCRIPTION
The `next/image` mock in `AlbumTile.test.tsx` returned `<img alt={alt} />` with an `eslint-disable-line` comment to silence `@next/next/no-img-element`. The tests don't assert on image rendering at all — they only check `ConditionSlider` price output — so the mock just needs to not throw. Returning `null` is correct and removes the suppress comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)