### PR TITLE
fix: strip markdown fences from Claude response before JSON.parse

### DIFF
--- a/app/api/identify/route.test.ts
+++ b/app/api/identify/route.test.ts
@@ -130,6 +130,34 @@ describe('POST /api/identify', () => {
     });
   });
 
+  it('parses JSON wrapped in ```json markdown fences', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: '```json\n{"query":"Pink Floyd - The Dark Side of the Moon","condition":"Very Good (VG)"}\n```' }],
+    });
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest(makeFile()));
+
+    expect(await res.json()).toEqual({
+      query: 'Pink Floyd - The Dark Side of the Moon',
+      condition: 'Very Good (VG)',
+    });
+  });
+
+  it('parses JSON wrapped in plain ``` markdown fences', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: '```\n{"query":"Pink Floyd - The Dark Side of the Moon","condition":null}\n```' }],
+    });
+
+    const { POST } = await import('./route');
+    const res = await POST(makeRequest(makeFile()));
+
+    expect(await res.json()).toEqual({
+      query: 'Pink Floyd - The Dark Side of the Moon',
+      condition: null,
+    });
+  });
+
   it('returns { query: "UNKNOWN", condition: null } when Claude returns invalid JSON', async () => {
     mockCreate.mockResolvedValueOnce({
       content: [{ type: 'text', text: 'not valid json at all' }],

--- a/app/api/identify/route.ts
+++ b/app/api/identify/route.ts
@@ -72,7 +72,8 @@ export async function POST(req: Request) {
 
     if (raw) {
       try {
-        const parsed = JSON.parse(raw) as { query?: unknown; condition?: unknown };
+        const stripped = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+        const parsed = JSON.parse(stripped) as { query?: unknown; condition?: unknown };
         if (typeof parsed.query === 'string') query = parsed.query.trim();
         if (typeof parsed.condition === 'string') condition = parsed.condition;
       } catch {


### PR DESCRIPTION
## Root cause

The condition estimation feature changed `/api/identify` to request JSON from Claude Haiku. Haiku frequently wraps JSON in ` ```json ``` ` blocks even when explicitly told not to. The `JSON.parse` call would throw on the fenced string, the `catch` block silently set `query = 'UNKNOWN'`, and the scanner showed "Couldn't identify this cover" for every album including well-known ones.

## Fix

Strip leading ` ```json ` or ` ``` ` and trailing ` ``` ` fences from the raw response text before passing to `JSON.parse`. Unfenced responses (the happy path) are unaffected since the regex matches nothing.

## Tests added

- Parses JSON wrapped in ` ```json ``` ` fences
- Parses JSON wrapped in plain ` ``` ` fences

🤖 Generated with [Claude Code](https://claude.com/claude-code)