### PR TITLE
chore: add npm audit step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
+      - run: npm audit --audit-level=high --omit=dev
       - run: npm test
       - run: npm run lint
       - run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- Adds `npm audit --audit-level=high --omit=dev` to the `test` job, aligning with the global TDD workflow

## Notes
GitHub flagged 2 moderate vulnerabilities on `main` — these are pre-existing and won't block CI at `--audit-level=high`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)