### PR TITLE
refactor: split ConfigProps into site/app, update meta description

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ import "./globals.css";
 const font = Inter({ subsets: ["latin"] });
 
 export const viewport: Viewport = {
-  themeColor: config.colors.main,
+  themeColor: config.site.colors.main,
   width: "device-width",
   initialScale: 1,
 };
@@ -18,7 +18,7 @@ export const metadata = getSEOTags();
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" data-theme={config.colors.theme} className={font.className}>
+    <html lang="en" data-theme={config.site.colors.theme} className={font.className}>
       <body>
         <ClientLayout>{children}</ClientLayout>
       </body>

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -26,7 +26,7 @@ import config from "@/config";
 // Please write a simple privacy policy for my site. Add the current date.  Do not add or explain your reasoning. Answer:
 
 export const metadata = getSEOTags({
-  title: `Privacy Policy | ${config.appName}`,
+  title: `Privacy Policy | ${config.app.name}`,
   canonicalUrlRelative: "/privacy-policy",
 });
 
@@ -50,7 +50,7 @@ const PrivacyPolicy = () => {
           Back
         </Link>
         <h1 className="text-3xl font-extrabold pb-6">
-          Privacy Policy for {config.appName}
+          Privacy Policy for {config.app.name}
         </h1>
 
         <pre

--- a/app/tos/page.tsx
+++ b/app/tos/page.tsx
@@ -26,7 +26,7 @@ import config from "@/config";
 // Please write a simple Terms & Services for my site. Add the current date. Do not add or explain your reasoning. Answer:
 
 export const metadata = getSEOTags({
-  title: `Terms and Conditions | ${config.appName}`,
+  title: `Terms and Conditions | ${config.app.name}`,
   canonicalUrlRelative: "/tos",
 });
 
@@ -50,7 +50,7 @@ const TOS = () => {
           Back
         </Link>
         <h1 className="text-3xl font-extrabold pb-6">
-          Terms and Conditions for {config.appName}
+          Terms and Conditions for {config.app.name}
         </h1>
 
         <pre

--- a/components/LayoutClient.tsx
+++ b/components/LayoutClient.tsx
@@ -10,7 +10,7 @@ import { CurrencyProvider } from "@/app/currency-provider";
 const ClientLayout = ({ children }: { children: ReactNode }) => {
   return (
     <>
-      <NextTopLoader color={config.colors.main} showSpinner={false} />
+      <NextTopLoader color={config.site.colors.main} showSpinner={false} />
       <CurrencyProvider>
         {children}
         <Toaster toastOptions={{ duration: 3000 }} />

--- a/config.ts
+++ b/config.ts
@@ -1,13 +1,19 @@
 import { ConfigProps } from "./types/config";
 
-const config = {
-  appName: "Crate Mole",
-  appDescription: "Find vinyl prices and info for any record.",
-  domainName: "unwave.net",
-  colors: {
-    theme: "lofi",
-    main: "#0f172a",
+const config: ConfigProps = {
+  site: {
+    name: "Unwave Network",
+    domainName: "unwave.net",
+    colors: {
+      theme: "lofi",
+      main: "#0f172a",
+    },
   },
-} as ConfigProps;
+  app: {
+    name: "Crate Mole",
+    description:
+      "The record companion that gets out of your way. A quick snapshot of any album — info, ratings, and more — no rabbit holes.",
+  },
+};
 
 export default config;

--- a/libs/seo.tsx
+++ b/libs/seo.tsx
@@ -19,24 +19,24 @@ export const getSEOTags = ({
 } = {}) => {
   return {
     // up to 50 characters (what does your app do for the user?) > your main should be here
-    title: title || config.appName,
+    title: title || `${config.app.name} | ${config.site.name}`,
     // up to 160 characters (how does your app help the user?)
-    description: description || config.appDescription,
+    description: description || config.app.description,
     // some keywords separated by commas. by default it will be your app name
-    keywords: keywords || [config.appName],
-    applicationName: config.appName,
+    keywords: keywords || [config.app.name],
+    applicationName: config.app.name,
     // set a base URL prefix for other fields that require a fully qualified URL (.e.g og:image: og:image: 'https://yourdomain.com/share.png' => '/share.png')
     metadataBase: new URL(
       process.env.NODE_ENV === "development"
         ? "http://localhost:3000/"
-        : `https://${config.domainName}/`
+        : `https://${config.site.domainName}/`
     ),
 
     openGraph: {
-      title: openGraph?.title || config.appName,
-      description: openGraph?.description || config.appDescription,
-      url: openGraph?.url || `https://${config.domainName}/`,
-      siteName: openGraph?.title || config.appName,
+      title: openGraph?.title || `${config.app.name} | ${config.site.name}`,
+      description: openGraph?.description || config.app.description,
+      url: openGraph?.url || `https://${config.site.domainName}/`,
+      siteName: openGraph?.title || config.app.name,
       // If you add an opengraph-image.(jpg|jpeg|png|gif) image to the /app folder, you don't need the code below
       // images: [
       //   {
@@ -50,8 +50,8 @@ export const getSEOTags = ({
     },
 
     twitter: {
-      title: openGraph?.title || config.appName,
-      description: openGraph?.description || config.appDescription,
+      title: openGraph?.title || `${config.app.name} | ${config.site.name}`,
+      description: openGraph?.description || config.app.description,
       // If you add an twitter-image.(jpg|jpeg|png|gif) image to the /app folder, you don't need the code below
       // images: [openGraph?.image || defaults.og.image],
       card: "summary_large_image",
@@ -83,10 +83,10 @@ export const renderSchemaTags = () => {
         __html: JSON.stringify({
           "@context": "http://schema.org",
           "@type": "SoftwareApplication",
-          name: config.appName,
-          description: config.appDescription,
-          image: `https://${config.domainName}/icon.png`,
-          url: `https://${config.domainName}/`,
+          name: config.app.name,
+          description: config.app.description,
+          image: `https://${config.site.domainName}/icon.png`,
+          url: `https://${config.site.domainName}/`,
           author: {
             "@type": "Person",
             name: "William Smallman-Koepf",

--- a/types/config.ts
+++ b/types/config.ts
@@ -22,12 +22,24 @@ export type Theme =
   | "dracula"
   | "nord";
 
-export interface ConfigProps {
-  appName: string;
-  appDescription: string;
+/** Shared across all tools on the Unwave Network site. */
+export interface SiteConfig {
+  name: string;
   domainName: string;
   colors: {
     theme: Theme;
     main: string;
   };
+}
+
+/** Per-tool config. Add one AppConfig per tool hosted on the site. */
+export interface AppConfig {
+  /** Composes with site.name to form page titles: "<app.name> | <site.name>". */
+  name: string;
+  description: string;
+}
+
+export interface ConfigProps {
+  site: SiteConfig;
+  app: AppConfig;
 }


### PR DESCRIPTION
## Summary

- Splits `ConfigProps` into `SiteConfig` (brand, domain, colours — shared across all Unwave tools) and `AppConfig` (name, description — per tool), composed under `config.site` and `config.app`
- Updates all consumers (`layout.tsx`, `LayoutClient`, `seo.tsx`, `tos`, `privacy-policy`) to the new paths
- Updates the OG/Twitter/meta description to lead with the "gets out of your way" positioning
- Page titles now compose as `"Crate Mole | Unwave Network"` across all social previews

## Why

When a second tool is added to the site, `brandName`/`domainName`/`colors` should be defined once — not copied into each tool's config. This structure makes that boundary explicit in both the types and the data.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Browser tab shows "Crate Mole | Unwave Network"
- [ ] WhatsApp/social preview description leads with "The record companion that gets out of your way…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)