### PR TITLE
chore: ignore playwright output dirs and claude local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# claude code
+.claude/settings.local.json
+
 # typescript
 *.tsbuildinfo
 # next-env.d.ts is intentionally tracked — CI needs it for tsc --noEmit


### PR DESCRIPTION
## Summary

- Adds `/playwright-report` and `/test-results` to `.gitignore` — generated by `npm run test:e2e`, no reason to track
- Adds `.claude/settings.local.json` — machine-local Claude Code permission overrides, shouldn't be shared
- Deletes `-H` and `-d` junk files that were accidentally created by a malformed shell command

🤖 Generated with [Claude Code](https://claude.com/claude-code)